### PR TITLE
[Feat/#19] FolderCell, ClipCell UI 구현

### DIFF
--- a/Clipster/Clipster/Presentation/Model/ClipCellDisplay.swift
+++ b/Clipster/Clipster/Presentation/Model/ClipCellDisplay.swift
@@ -4,4 +4,5 @@ struct ClipCellDisplay: Hashable {
     let thumbnailImageURL: URL
     let title: String
     let memo: String
+    let isVisited: Bool
 }

--- a/Clipster/Clipster/Presentation/Model/ClipCellDisplay.swift
+++ b/Clipster/Clipster/Presentation/Model/ClipCellDisplay.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct ClipCellDisplay: Hashable {
+    let thumbnailImageURL: URL
+    let title: String
+    let memo: String
+}

--- a/Clipster/Clipster/Presentation/Model/FolderCellDisplay.swift
+++ b/Clipster/Clipster/Presentation/Model/FolderCellDisplay.swift
@@ -1,0 +1,4 @@
+struct FolderCellDisplay: Hashable {
+    let title: String
+    let itemCount: Int
+}

--- a/Clipster/Clipster/Presentation/Scene/Common/ClipCell.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/ClipCell.swift
@@ -32,6 +32,14 @@ final class ClipCell: UICollectionViewCell {
         return stackView
     }()
 
+    private let visitIndicatorView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemBlue
+        view.layer.cornerRadius = 4
+        view.isHidden = true
+        return view
+    }()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         configure()
@@ -45,6 +53,7 @@ final class ClipCell: UICollectionViewCell {
         thumbnailImageView.kf.setImage(with: display.thumbnailImageURL)
         titleLabel.text = display.title
         memoLabel.text = display.memo
+        visitIndicatorView.isHidden = display.isVisited
     }
 }
 
@@ -72,7 +81,8 @@ private extension ClipCell {
     func setHierarchy() {
         [
             thumbnailImageView,
-            stackView
+            stackView,
+            visitIndicatorView
         ].forEach { addSubview($0) }
     }
 
@@ -85,7 +95,13 @@ private extension ClipCell {
 
         stackView.snp.makeConstraints { make in
             make.leading.equalTo(thumbnailImageView.snp.trailing).offset(8)
+            make.trailing.equalToSuperview().inset(16)
             make.centerY.equalToSuperview()
+        }
+
+        visitIndicatorView.snp.makeConstraints { make in
+            make.top.leading.equalToSuperview().inset(8)
+            make.size.equalTo(8)
         }
     }
 }

--- a/Clipster/Clipster/Presentation/Scene/Common/ClipCell.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/ClipCell.swift
@@ -1,0 +1,91 @@
+import Kingfisher
+import SnapKit
+import UIKit
+
+final class ClipCell: UICollectionViewCell {
+    private let thumbnailImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.layer.cornerRadius = 12
+        imageView.clipsToBounds = true
+        return imageView
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14, weight: .semibold)
+        label.textColor = .label
+        return label
+    }()
+
+    private let memoLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 12, weight: .regular)
+        label.textColor = .systemGray
+        return label
+    }()
+
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, memoLabel])
+        stackView.axis = .vertical
+        stackView.spacing = 8
+        return stackView
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setDisplay(_ display: ClipCellDisplay) {
+        thumbnailImageView.kf.setImage(with: display.thumbnailImageURL)
+        titleLabel.text = display.title
+        memoLabel.text = display.memo
+    }
+}
+
+private extension ClipCell {
+    func configure() {
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+    }
+
+    func setAttributes() {
+        backgroundColor = .systemBackground
+
+        layer.cornerRadius = 16
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.25
+        layer.shadowOffset = CGSize(width: 0, height: 2)
+        layer.shadowRadius = 4
+        layer.shadowPath = UIBezierPath(
+            roundedRect: bounds,
+            cornerRadius: layer.cornerRadius
+        ).cgPath
+    }
+
+    func setHierarchy() {
+        [
+            thumbnailImageView,
+            stackView
+        ].forEach { addSubview($0) }
+    }
+
+    func setConstraints() {
+        thumbnailImageView.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(16)
+            make.verticalEdges.equalToSuperview().inset(12)
+            make.width.equalTo(thumbnailImageView.snp.height)
+        }
+
+        stackView.snp.makeConstraints { make in
+            make.leading.equalTo(thumbnailImageView.snp.trailing).offset(8)
+            make.centerY.equalToSuperview()
+        }
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/Common/FolderCell.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/FolderCell.swift
@@ -1,0 +1,119 @@
+import Kingfisher
+import SnapKit
+import UIKit
+
+final class FolderCell: UICollectionViewCell {
+    private let folderImageContainerView: UIView = {
+        let imageView = UIImageView()
+        imageView.backgroundColor = .systemBlue
+        imageView.layer.cornerRadius = 12
+        return imageView
+    }()
+
+    private let folderImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "folder")
+        imageView.contentMode = .scaleAspectFit
+        imageView.tintColor = .systemIndigo
+        return imageView
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14, weight: .semibold)
+        label.textColor = .label
+        return label
+    }()
+
+    private let itemCountLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 12, weight: .regular)
+        label.textColor = .systemGray
+        return label
+    }()
+
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, itemCountLabel])
+        stackView.axis = .vertical
+        stackView.spacing = 8
+        return stackView
+    }()
+
+    private let chevronImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "chevron.right")
+        imageView.contentMode = .scaleAspectFit
+        imageView.tintColor = .systemGray
+        return imageView
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func setDisplay(_ display: FolderCellDisplay) {
+        titleLabel.text = display.title
+        itemCountLabel.text = "\(display.itemCount) items"
+    }
+}
+
+private extension FolderCell {
+    func configure() {
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+    }
+
+    func setAttributes() {
+        backgroundColor = .systemBackground
+
+        layer.cornerRadius = 16
+        layer.shadowColor = UIColor.black.cgColor
+        layer.shadowOpacity = 0.25
+        layer.shadowOffset = CGSize(width: 0, height: 2)
+        layer.shadowRadius = 4
+        layer.shadowPath = UIBezierPath(
+            roundedRect: bounds,
+            cornerRadius: layer.cornerRadius
+        ).cgPath
+    }
+
+    func setHierarchy() {
+        [
+            folderImageContainerView,
+            stackView,
+            chevronImageView
+        ].forEach { addSubview($0) }
+
+        folderImageContainerView.addSubview(folderImageView)
+    }
+
+    func setConstraints() {
+        folderImageContainerView.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(16)
+            make.verticalEdges.equalToSuperview().inset(12)
+            make.width.equalTo(folderImageContainerView.snp.height)
+        }
+
+        folderImageView.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(10)
+        }
+
+        stackView.snp.makeConstraints { make in
+            make.leading.equalTo(folderImageContainerView.snp.trailing).offset(8)
+            make.centerY.equalToSuperview()
+        }
+
+        chevronImageView.snp.makeConstraints { make in
+            make.leading.equalTo(stackView.snp.trailing).offset(8)
+            make.trailing.equalToSuperview().inset(16)
+            make.centerY.equalToSuperview()
+            make.size.equalTo(16)
+        }
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/Common/FolderCell.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/FolderCell.swift
@@ -1,4 +1,3 @@
-import Kingfisher
 import SnapKit
 import UIKit
 


### PR DESCRIPTION
## 📌 관련 이슈
close #19 
  
## 📌 PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- FolderCell UI 구현
- FolderCellDisplay 정의
- ClipCell UI 구현
- ClipCellDisplay 정의

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/b8de4a01-55d7-458a-a5a0-470719fd6438" width="250px"> |
| Debug View Hierarchy | <img src="https://github.com/user-attachments/assets/b5f3ef81-9eaa-46f9-b1c3-94304a93b30a" width="250px"> |

## 📌 참고 사항
- 최대한 Figma를 참고하여 구현하였습니다.
- chevronImageView, folderImageView의 경우 피그마의 크기대로 하니 너무 작아 임의로 조금 키워서 구현
- folderImageView의 경우 systemColor중에서 골라서 어색할 수 있음(추후 수정)
- 피그마 설정보다 조금 더 어둡게 그림자 설정
