### PR TITLE
[Feat] EditFolder UI 구현

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/Button/EditFolderBackButton.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/Button/EditFolderBackButton.swift
@@ -1,0 +1,53 @@
+import SnapKit
+import UIKit
+
+final class EditFolderBackButton: UIView {
+    private let backButton = UIButton()
+    private let titleLabel = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    func setDisplay(_ title: String) {
+        titleLabel.text = title
+    }
+}
+
+private extension EditFolderBackButton {
+    func configure() {
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+    }
+
+    func setAttributes() {
+        backButton.setImage(UIImage(systemName: "arrow.left"), for: .normal)
+        backButton.tintColor = .systemBlue
+
+        titleLabel.font = .boldSystemFont(ofSize: 17)
+        titleLabel.textColor = .label
+    }
+
+    func setHierarchy() {
+        [backButton, titleLabel]
+            .forEach { addSubview($0) }
+    }
+
+    func setConstraints() {
+        backButton.snp.makeConstraints { make in
+            make.leading.top.bottom.equalToSuperview()
+            make.width.height.equalTo(24)
+        }
+
+        titleLabel.snp.makeConstraints { make in
+            make.leading.equalTo(backButton.snp.trailing).offset(8)
+            make.centerY.trailing.equalToSuperview()
+        }
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/Button/EditFolderBackButton.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/Button/EditFolderBackButton.swift
@@ -6,7 +6,6 @@ final class EditFolderBackButton: UIView {
         let button = UIButton()
         button.setImage(UIImage(systemName: "arrow.left"), for: .normal)
         button.tintColor = .systemBlue
-
         return button
     }()
 

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/Button/EditFolderBackButton.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/Button/EditFolderBackButton.swift
@@ -2,8 +2,20 @@ import SnapKit
 import UIKit
 
 final class EditFolderBackButton: UIView {
-    private let backButton = UIButton()
-    private let titleLabel = UILabel()
+    private let backButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "arrow.left"), for: .normal)
+        button.tintColor = .systemBlue
+
+        return button
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .boldSystemFont(ofSize: 17)
+        label.textColor = .label
+        return label
+    }()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -21,17 +33,8 @@ final class EditFolderBackButton: UIView {
 
 private extension EditFolderBackButton {
     func configure() {
-        setAttributes()
         setHierarchy()
         setConstraints()
-    }
-
-    func setAttributes() {
-        backButton.setImage(UIImage(systemName: "arrow.left"), for: .normal)
-        backButton.tintColor = .systemBlue
-
-        titleLabel.font = .boldSystemFont(ofSize: 17)
-        titleLabel.textColor = .label
     }
 
     func setHierarchy() {

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/Button/EditFolderSaveButton.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/Button/EditFolderSaveButton.swift
@@ -1,0 +1,23 @@
+import UIKit
+
+final class EditFolderSaveButton: UIButton {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
+
+private extension EditFolderSaveButton {
+    func configure() {
+        setAttributes()
+    }
+
+    func setAttributes() {
+        setTitle("저장", for: .normal)
+        setTitleColor(.systemBlue, for: .normal)
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/TextField/EditFolderTextField.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/TextField/EditFolderTextField.swift
@@ -1,0 +1,39 @@
+import UIKit
+
+final class EditFolderTextField: UITextField {
+    let textPadding = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    override func placeholderRect(forBounds bounds: CGRect) -> CGRect {
+        bounds.inset(by: textPadding)
+    }
+
+    override func textRect(forBounds bounds: CGRect) -> CGRect {
+        bounds.inset(by: textPadding)
+    }
+
+    override func editingRect(forBounds bounds: CGRect) -> CGRect {
+        bounds.inset(by: textPadding)
+    }
+}
+
+extension EditFolderTextField {
+    func configure() {
+        setAttributes()
+    }
+
+    func setAttributes() {
+        clearButtonMode = .whileEditing
+        placeholder = "폴더 이름"
+        layer.cornerRadius = 10
+        backgroundColor = .secondarySystemBackground
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/TextField/EditFolderTextField.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/TextField/EditFolderTextField.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 final class EditFolderTextField: UITextField {
-    let textPadding = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+    let textPadding = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 32)
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/View/EditFolderView.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/View/EditFolderView.swift
@@ -1,0 +1,34 @@
+import SnapKit
+import UIKit
+
+final class EditFolderView: UIView {
+    private let folderTitleTextField = EditFolderTextField()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
+
+private extension EditFolderView {
+    func configure() {
+        setHierarchy()
+        setConstraints()
+    }
+
+    func setHierarchy() {
+        addSubview(folderTitleTextField)
+    }
+
+    func setConstraints() {
+        folderTitleTextField.snp.makeConstraints { make in
+            make.top.equalToSuperview()
+            make.horizontalEdges.equalToSuperview()
+            make.height.equalTo(44)
+        }
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/View/EditFolderView.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/View/EditFolderView.swift
@@ -2,6 +2,8 @@ import SnapKit
 import UIKit
 
 final class EditFolderView: UIView {
+    let backButton = EditFolderBackButton()
+    let saveButton = EditFolderSaveButton()
     private let folderTitleTextField = EditFolderTextField()
 
     override init(frame: CGRect) {
@@ -26,8 +28,8 @@ private extension EditFolderView {
 
     func setConstraints() {
         folderTitleTextField.snp.makeConstraints { make in
-            make.top.equalToSuperview()
-            make.horizontalEdges.equalToSuperview()
+            make.top.equalTo(safeAreaLayoutGuide).offset(16)
+            make.horizontalEdges.equalToSuperview().inset(16)
             make.height.equalTo(44)
         }
     }

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
@@ -1,7 +1,7 @@
 import SnapKit
 import UIKit
 
-final class EditFolderViewController: UIViewController, UIGestureRecognizerDelegate {
+final class EditFolderViewController: UIViewController {
     private let backButton = EditFolderBackButton()
     private let saveButton = EditFolderSaveButton()
     private let editFolderView = EditFolderView()

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
@@ -1,0 +1,40 @@
+import SnapKit
+import UIKit
+
+final class EditFolderViewController: UIViewController, UIGestureRecognizerDelegate {
+    private let backButton = EditFolderBackButton()
+    private let saveButton = EditFolderSaveButton()
+    private let editFolderView = EditFolderView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configure()
+    }
+}
+
+private extension EditFolderViewController {
+    func configure() {
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+    }
+
+    func setAttributes() {
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backButton)
+
+        let rightBarButton = UIBarButtonItem(customView: saveButton)
+        navigationItem.rightBarButtonItem = rightBarButton
+    }
+
+    func setHierarchy() {
+        view.addSubview(editFolderView)
+    }
+
+    func setConstraints() {
+        editFolderView.snp.makeConstraints { make in
+            make.top.equalTo(view.safeAreaLayoutGuide).offset(16)
+            make.bottom.equalToSuperview()
+            make.horizontalEdges.equalToSuperview().inset(16)
+        }
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
@@ -2,9 +2,11 @@ import SnapKit
 import UIKit
 
 final class EditFolderViewController: UIViewController {
-    private let backButton = EditFolderBackButton()
-    private let saveButton = EditFolderSaveButton()
     private let editFolderView = EditFolderView()
+
+    override func loadView() {
+        view = editFolderView
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -15,26 +17,12 @@ final class EditFolderViewController: UIViewController {
 private extension EditFolderViewController {
     func configure() {
         setAttributes()
-        setHierarchy()
-        setConstraints()
     }
 
     func setAttributes() {
-        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backButton)
+        navigationItem.leftBarButtonItem = UIBarButtonItem(customView: editFolderView.backButton)
 
-        let rightBarButton = UIBarButtonItem(customView: saveButton)
+        let rightBarButton = UIBarButtonItem(customView: editFolderView.saveButton)
         navigationItem.rightBarButtonItem = rightBarButton
-    }
-
-    func setHierarchy() {
-        view.addSubview(editFolderView)
-    }
-
-    func setConstraints() {
-        editFolderView.snp.makeConstraints { make in
-            make.top.equalTo(view.safeAreaLayoutGuide).offset(16)
-            make.bottom.equalToSuperview()
-            make.horizontalEdges.equalToSuperview().inset(16)
-        }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

close #7 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

- Back Button
- Save Button
- TextField

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/4a70a698-a68f-4de7-99cd-9bfd59733862" width="250px"> |

## 📌 참고 사항

- base가 `feat/#8-edit-folder-vm` 브랜치인 것은 병합되지 않은 커밋(ViewModel 관련)이 PR에 잡히지 않게 하기 위함입니다.
  리뷰 후에는 `dev` 브랜치로 병합할 예정입니다.
- 타이틀이 비어있는 이유는 현재 기획상 이전 화면의 이름(상위 폴더 이름인 것 같습니다.)을 사용하는 것으로 되어 있어서,
  화면 전환 시 전달 받는 것으로 설계했기 때문입니다.
- 내비게이션 버튼들의 위치가 현재는 공통 뷰가 아닌 EditFolder의 커스텀 뷰로 되어 있는데요.
  우선은 제 생각대로 작업을 진행했기 때문에, 공통으로 빼지 않았습니다.
  다른 분들이 더 좋은 방법으로 구현하실 수도 있을 것 같아서, 협의 후에 수정하도록 하겠습니다.