### PR TITLE
[Feat] EditFolder UI 바인딩

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/Button/EditFolderBackButton.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/Button/EditFolderBackButton.swift
@@ -1,3 +1,4 @@
+import RxCocoa
 import SnapKit
 import UIKit
 
@@ -15,6 +16,8 @@ final class EditFolderBackButton: UIView {
         label.textColor = .label
         return label
     }()
+
+    var tap: ControlEvent<Void> { backButton.rx.tap }
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/Button/EditFolderSaveButton.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/Button/EditFolderSaveButton.swift
@@ -19,5 +19,6 @@ private extension EditFolderSaveButton {
     func setAttributes() {
         setTitle("저장", for: .normal)
         setTitleColor(.systemBlue, for: .normal)
+        setTitleColor(.systemGray, for: .disabled)
     }
 }

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/View/EditFolderView.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/Subview/View/EditFolderView.swift
@@ -1,3 +1,4 @@
+import RxSwift
 import SnapKit
 import UIKit
 
@@ -6,6 +7,14 @@ final class EditFolderView: UIView {
     let saveButton = EditFolderSaveButton()
     private let folderTitleTextField = EditFolderTextField()
 
+    var folderTitleChanges: Observable<String> {
+        folderTitleTextField.rx.text.orEmpty.asObservable()
+    }
+
+    var folderTitleBinder: Binder<String?> {
+        folderTitleTextField.rx.text
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         configure()
@@ -13,6 +22,10 @@ final class EditFolderView: UIView {
 
     required init?(coder: NSCoder) {
         super.init(coder: coder)
+    }
+
+    func setTextFieldInteraction(enabled: Bool) {
+        folderTitleTextField.isUserInteractionEnabled = enabled
     }
 }
 

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
@@ -1,8 +1,22 @@
+import RxCocoa
+import RxSwift
 import SnapKit
 import UIKit
 
 final class EditFolderViewController: UIViewController {
+    private let viewModel: EditFolderViewModel
+    private let disposeBag = DisposeBag()
+
     private let editFolderView = EditFolderView()
+
+    init(viewModel: EditFolderViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func loadView() {
         view = editFolderView
@@ -17,6 +31,7 @@ final class EditFolderViewController: UIViewController {
 private extension EditFolderViewController {
     func configure() {
         setAttributes()
+        setBindings()
     }
 
     func setAttributes() {
@@ -24,5 +39,80 @@ private extension EditFolderViewController {
 
         let rightBarButton = UIBarButtonItem(customView: editFolderView.saveButton)
         navigationItem.rightBarButtonItem = rightBarButton
+    }
+
+    func setBindings() {
+        viewModel.state
+            .map { $0.navigationTitle }
+            .distinctUntilChanged()
+            .observe(on: MainScheduler.instance)
+            .bind { [weak self] title in
+                self?.editFolderView.backButton.setDisplay(title)
+            }
+            .disposed(by: disposeBag)
+
+        viewModel.state
+            .map { $0.isSavable }
+            .distinctUntilChanged()
+            .observe(on: MainScheduler.instance)
+            .bind(to: editFolderView.saveButton.rx.isEnabled)
+            .disposed(by: disposeBag)
+
+        viewModel.state
+            .map { $0.isProcessing }
+            .distinctUntilChanged()
+            .observe(on: MainScheduler.instance)
+            .subscribe { [weak self] isProcessing in
+                guard let self else { return }
+                self.editFolderView.saveButton.isUserInteractionEnabled = !isProcessing
+                self.editFolderView.saveButton.alpha = isProcessing ? 0.5 : 1.0
+                self.editFolderView.setTextFieldInteraction(enabled: !isProcessing)
+            }
+            .disposed(by: disposeBag)
+
+        viewModel.state
+            .compactMap { $0.alertMessage }
+            .observe(on: MainScheduler.instance)
+            .subscribe { [weak self] message in
+                let alert = UIAlertController(title: "알림", message: message, preferredStyle: .alert)
+                alert.addAction(UIAlertAction(title: "확인", style: .default, handler: nil))
+                self?.present(alert, animated: true, completion: nil)
+            }
+            .disposed(by: disposeBag)
+
+        viewModel.state
+            .map { $0.shouldDismiss }
+            .distinctUntilChanged()
+            .filter { $0 }
+            .observe(on: MainScheduler.instance)
+            .subscribe { [weak self] _ in
+                self?.navigationController?.popViewController(animated: true)
+            }
+            .disposed(by: disposeBag)
+
+        viewModel.state
+            .map { $0.folderTitle }
+            .distinctUntilChanged()
+            .observe(on: MainScheduler.instance)
+            .bind(to: editFolderView.folderTitleBinder)
+            .disposed(by: disposeBag)
+
+        editFolderView.backButton.tap
+            .observe(on: MainScheduler.instance)
+            .subscribe { [weak self] _ in
+                self?.navigationController?.popViewController(animated: true)
+            }
+            .disposed(by: disposeBag)
+
+        editFolderView.folderTitleChanges
+            .distinctUntilChanged()
+            .map { .folderTitleChanged($0) }
+            .bind(to: viewModel.action)
+            .disposed(by: disposeBag)
+
+        editFolderView.saveButton.rx.tap
+            .map { EditFolderAction.saveButtonTapped }
+            .bind(to: viewModel.action)
+            .disposed(by: disposeBag)
     }
 }

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/ViewModel/EditFolderViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/ViewModel/EditFolderViewModel.swift
@@ -99,11 +99,9 @@ final class EditFolderViewModel {
             .disposed(by: disposeBag)
 
         action
-            .filter {
-                if case .saveButtonTapped = $0 { return true } else { return false }
-            }
+            .filter { if case .saveButtonTapped = $0 { return true } else { return false } }
             .withLatestFrom(stateRelay)
-            .filter { $0.isSavable && !$0.isProcessing }
+            .filter { $0.isSavable }
             .flatMapLatest { currentState in
                 let title = currentState.folderTitle.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -116,6 +114,7 @@ final class EditFolderViewModel {
                     return Observable<EditFolderAction>.just(.saveSucceeded)
                 }
             }
+            .observe(on: MainScheduler.asyncInstance)
             .bind(to: action)
             .disposed(by: disposeBag)
     }


### PR DESCRIPTION
## 📌 관련 이슈

close #9 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

View <-> ViewModel 바인딩

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/7039261b-f9fa-4619-99ca-b3a09aae3258" width="250px"> | <img src="https://github.com/user-attachments/assets/c8204db0-3133-410a-b12b-9e5bfd01f1d7" width="250px"> |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/9f28bc17-f6ef-4833-a3e1-2522e2ef656c" width="250px"> |  |

## 📌 참고 사항

1. 테스트는 홈 화면 등에서 아래 코드를 사용하시면 됩니다.
```swift
//        let editVM = EditFolderViewModel(mode: .add(parentFolderID: nil, parentFolderTitle: "Home"))
        let folder = Folder(
            id: UUID(),
            parentFolderID: UUID(),
            title: "TEST",
            depth: 1,
            folders: [],
            clips: [],
            createdAt: Date(),
            updatedAt: Date(),
            deletedAt: nil
        )
        let editVM = EditFolderViewModel(mode: .edit(folderToEdit: folder, parentFolderTitle: "Parent"))
        let editVC = EditFolderViewController(viewModel: editVM)
        navigationController?.pushViewController(editVC, animated: true)
```
