### PR TITLE
[Feat] EditClipView 구현

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/EditClip/Subview/StackView/URLValidationStackView.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Subview/StackView/URLValidationStackView.swift
@@ -1,0 +1,55 @@
+import SnapKit
+import UIKit
+
+final class URLValidationStackView: UIStackView {
+    private let statusImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = UIImage(systemName: "checkmark.circle.fill")
+        imageView.tintColor = .green
+        return imageView
+    }()
+
+    private let statusLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .secondaryLabel
+        label.font = .systemFont(ofSize: 13, weight: .light)
+        label.text = "올바른 URL 입니다"
+        return label
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension URLValidationStackView {
+    func configure() {
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+    }
+
+    func setAttributes() {
+        spacing = 8
+    }
+
+    func setHierarchy() {
+        [
+            statusImageView,
+            statusLabel
+        ].forEach {
+            addArrangedSubview($0)
+        }
+    }
+
+    func setConstraints() {
+        statusImageView.snp.makeConstraints { make in
+            make.size.equalTo(20)
+        }
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/EditClip/Subview/View/EditClipView.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Subview/View/EditClipView.swift
@@ -1,0 +1,96 @@
+import SnapKit
+import UIKit
+
+final class EditClipView: UIView {
+    let saveButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("저장", for: .normal)
+        button.setTitleColor(.tintColor, for: .normal)
+        button.setTitleColor(.lightGray, for: .disabled)
+        button.frame = .init(x: 0, y: 0, width: 44, height: 44)
+        return button
+    }()
+
+    private let urlInfoStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 16
+        return stackView
+    }()
+
+    let urlMetadataStackView: URLMetadataStackView = {
+        let stackView = URLMetadataStackView(type: .edit)
+        stackView.isHidden = true
+        return stackView
+    }()
+
+    private let textField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = "URL 입력"
+        textField.borderStyle = .roundedRect
+        return textField
+    }()
+
+    private let urlValidationStacKView: URLValidationStackView = {
+        let stackView = URLValidationStackView()
+        stackView.isHidden = true
+        return stackView
+    }()
+
+    private let memoTextView: UITextView = {
+        let textView = UITextView()
+        textView.layer.cornerRadius = 12
+        textView.clipsToBounds = true
+        textView.textContainerInset = .init(top: 16, left: 16, bottom: 16, right: 16)
+        textView.font = .systemFont(ofSize: 16)
+        textView.layer.borderWidth = 1
+        textView.layer.borderColor = UIColor.systemGray5.cgColor
+        return textView
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension EditClipView {
+    func configure() {
+        setHierarchy()
+        setConstraints()
+    }
+
+    func setHierarchy() {
+        [
+            urlMetadataStackView,
+            textField,
+            urlValidationStacKView
+        ].forEach {
+            urlInfoStackView.addArrangedSubview($0)
+        }
+
+        [
+            urlInfoStackView,
+            memoTextView
+        ].forEach {
+            addSubview($0)
+        }
+    }
+
+    func setConstraints() {
+        urlInfoStackView.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide).offset(20)
+            make.directionalHorizontalEdges.equalToSuperview().inset(20)
+        }
+
+        memoTextView.snp.makeConstraints { make in
+            make.top.equalTo(urlInfoStackView.snp.bottom).offset(20)
+            make.directionalHorizontalEdges.equalToSuperview().inset(20)
+            make.height.equalTo(120)
+        }
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -1,0 +1,33 @@
+import UIKit
+
+final class EditClipViewController: UIViewController {
+    private let editClipView = EditClipView()
+
+    init(url: URL?) {
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        view = editClipView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configure()
+    }
+}
+
+private extension EditClipViewController {
+    func configure() {
+        setAttributes()
+    }
+
+    func setAttributes() {
+        view.backgroundColor = .systemBackground
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: editClipView.saveButton)
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

close #29 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- [x] editClipView UI 구현
- [x] URLValidationStackView UI 구현

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/87100f3d-3f26-48c6-908f-1bdfc87ee020" width="250px"> |

## 📌 참고 사항
VC에서 `init(url: URL)`는 EditClipViewController가 Share Extension/Toast View 등에서 URL을 전달 받고 push되는 경우 때문에 추가하였습니다.

