### PR TITLE
[Feat] EditClipViewModel 구현

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Common/StackView/URLMetadataStackView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/StackView/URLMetadataStackView.swift
@@ -15,6 +15,7 @@ final class URLMetadataStackView: UIStackView {
         imageView.contentMode = .scaleAspectFill
         imageView.layer.cornerRadius = 12
         imageView.clipsToBounds = true
+        imageView.image = .none
         return imageView
     }()
 
@@ -32,6 +33,7 @@ final class URLMetadataStackView: UIStackView {
         label.font = .systemFont(ofSize: 16, weight: .semibold)
         label.numberOfLines = 2
         label.textColor = .label
+        label.text = " "
         return label
     }()
 
@@ -40,6 +42,7 @@ final class URLMetadataStackView: UIStackView {
         label.font = .systemFont(ofSize: 13, weight: .medium)
         label.numberOfLines = 2
         label.textColor = .link
+        label.text = " "
         if case .edit = type { label.isHidden = true }
         return label
     }()

--- a/Clipster/Clipster/Presentation/Scene/EditClip/Subview/View/EditClipView.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Subview/View/EditClipView.swift
@@ -24,20 +24,20 @@ final class EditClipView: UIView {
         return stackView
     }()
 
-    private let textField: UITextField = {
+    let urlInputTextField: UITextField = {
         let textField = UITextField()
         textField.placeholder = "URL 입력"
         textField.borderStyle = .roundedRect
         return textField
     }()
 
-    private let urlValidationStacKView: URLValidationStackView = {
+    let urlValidationStacKView: URLValidationStackView = {
         let stackView = URLValidationStackView()
         stackView.isHidden = true
         return stackView
     }()
 
-    private let memoTextView: UITextView = {
+    let memoTextView: UITextView = {
         let textView = UITextView()
         textView.layer.cornerRadius = 12
         textView.clipsToBounds = true

--- a/Clipster/Clipster/Presentation/Scene/EditClip/Subview/View/EditClipView.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Subview/View/EditClipView.swift
@@ -48,6 +48,13 @@ final class EditClipView: UIView {
         return textView
     }()
 
+    let memoLimitLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .secondaryLabel
+        label.font = .monospacedDigitSystemFont(ofSize: 12, weight: .medium)
+        return label
+    }()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         configure()
@@ -67,7 +74,7 @@ private extension EditClipView {
     func setHierarchy() {
         [
             urlMetadataStackView,
-            textField,
+            urlInputTextField,
             urlValidationStacKView
         ].forEach {
             urlInfoStackView.addArrangedSubview($0)
@@ -75,7 +82,8 @@ private extension EditClipView {
 
         [
             urlInfoStackView,
-            memoTextView
+            memoTextView,
+            memoLimitLabel
         ].forEach {
             addSubview($0)
         }
@@ -91,6 +99,11 @@ private extension EditClipView {
             make.top.equalTo(urlInfoStackView.snp.bottom).offset(20)
             make.directionalHorizontalEdges.equalToSuperview().inset(20)
             make.height.equalTo(120)
+        }
+
+        memoLimitLabel.snp.makeConstraints { make in
+            make.top.equalTo(memoTextView.snp.bottom).offset(10)
+            make.right.equalToSuperview().inset(25)
         }
     }
 }

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
@@ -1,0 +1,48 @@
+import Foundation
+import RxRelay
+import RxSwift
+
+final class EditClipViewModel: ViewModel {
+    enum Action {
+        case editURLInputTextField(String)
+    }
+
+    enum Mutation {
+        case updateURLInputText(String)
+    }
+
+    struct State {
+        var urlInputText: String = ""
+        var isEmptyURLInput: Bool = false
+        var isHiddenURLMetadataStackView = false
+        var isHiddenURLValidationStackView = false
+    }
+
+    var state: BehaviorRelay<State>
+    var action = PublishRelay<Action>()
+    var disposeBag = DisposeBag()
+
+    init() {
+        state = BehaviorRelay(value: State())
+        bind()
+    }
+
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .editURLInputTextField(let urlText):
+            return .just(.updateURLInputText(urlText))
+        }
+    }
+
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        switch mutation {
+        case .updateURLInputText(let urlText):
+            newState.urlInputText = urlText
+            newState.isEmptyURLInput = newState.urlInputText.isEmpty
+            newState.isHiddenURLMetadataStackView = newState.urlInputText.isEmpty
+            newState.isHiddenURLValidationStackView = newState.urlInputText.isEmpty
+        }
+        return newState
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
@@ -5,10 +5,12 @@ import RxSwift
 final class EditClipViewModel: ViewModel {
     enum Action {
         case editURLInputTextField(String)
+        case editMomo(String)
     }
 
     enum Mutation {
         case updateURLInputText(String)
+        case updateMemo(String)
     }
 
     struct State {
@@ -16,6 +18,8 @@ final class EditClipViewModel: ViewModel {
         var isEmptyURLInput: Bool = false
         var isHiddenURLMetadataStackView = false
         var isHiddenURLValidationStackView = false
+        var memoText: String = ""
+        var memoLimit: String = "0/100"
     }
 
     var state: BehaviorRelay<State>
@@ -31,6 +35,8 @@ final class EditClipViewModel: ViewModel {
         switch action {
         case .editURLInputTextField(let urlText):
             return .just(.updateURLInputText(urlText))
+        case .editMomo(let memoText):
+            return .just(.updateMemo(memoText))
         }
     }
 
@@ -42,6 +48,9 @@ final class EditClipViewModel: ViewModel {
             newState.isEmptyURLInput = newState.urlInputText.isEmpty
             newState.isHiddenURLMetadataStackView = newState.urlInputText.isEmpty
             newState.isHiddenURLValidationStackView = newState.urlInputText.isEmpty
+        case .updateMemo(let memoText):
+            newState.memoText = memoText
+            newState.memoLimit = "\(memoText.count)/100"
         }
         return newState
     }

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/ViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/ViewModel.swift
@@ -1,0 +1,34 @@
+import Foundation
+import RxRelay
+import RxSwift
+
+protocol ViewModel: AnyObject {
+    associatedtype Action
+    associatedtype Mutation
+    associatedtype State
+
+    var state: BehaviorRelay<State> { get }
+    var action: PublishRelay<Action> { get }
+
+    var disposeBag: DisposeBag { get }
+
+    func mutate(action: Action) -> Observable<Mutation>
+    func reduce(state: State, mutation: Mutation) -> State
+    func bind()
+}
+
+extension ViewModel {
+    func bind() {
+        action
+            .flatMap { [weak self] action -> Observable<Mutation> in
+                guard let self else { return .empty() }
+                return mutate(action: action)
+            }
+            .subscribe { [weak self] mutation in
+                guard let self else { return }
+                let newState = reduce(state: state.value, mutation: mutation)
+                state.accept(newState)
+            }
+            .disposed(by: disposeBag)
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

close #49 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

<!-- 변경한 내용과 그 이유를 적어주세요 -->
- [x] Reactor 구조의 Action->Mutate->State 흐름으로 ViewModel 작성
- [x] 입력 받은 URL, 메모를 저장하는 State 
- [x] URL 입력하였을 때 상단 URLMetadata, 하단 URL Validation 숨기기/보이기에 대한 State 

- [x] 스택 뷰 관련 레이아웃 충돌 수정 (이미지와 label에 대한 기본 값을 가지도록)
- [x] UI Component 접근제어자 수정
- [x] 메모 글자 수를 제한하기 위한 Label 추가 ex) 0/100

## 📌 참고 사항

UI Component 추가 및 접근 제어자 수정 등을 ViewModel PR로 포함한 점은 이전 EditClipView에 작성해야할 부분이지만 당시에 생각 못 했고, 그것만 따로 분리하기엔 애매해서 포함 했습니다. 양해 부탁드립니다.