### PR TITLE
[Feat] EditClipView 바인딩

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -3,7 +3,8 @@ import UIKit
 final class EditClipViewController: UIViewController {
     private let editClipView = EditClipView()
 
-    init(url: URL?) {
+    init(viewModel: EditClipViewModel) {
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
@@ -14,20 +14,24 @@ final class EditClipViewModel: ViewModel {
     }
 
     struct State {
-        var urlInputText: String = ""
+        var urlInputText: String
         var isEmptyURLInput: Bool = false
         var isHiddenURLMetadataStackView = false
         var isHiddenURLValidationStackView = false
-        var memoText: String = ""
-        var memoLimit: String = "0/100"
+        var memoText: String
+        var memoLimit: String
     }
 
     var state: BehaviorRelay<State>
     var action = PublishRelay<Action>()
     var disposeBag = DisposeBag()
 
-    init() {
-        state = BehaviorRelay(value: State())
+    init(urlText: String = "", memoText: String = "") {
+        state = BehaviorRelay(value: State(
+            urlInputText: urlText,
+            memoText: memoText,
+            memoLimit: "\(memoText)/100"
+        ))
         bind()
     }
 

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
@@ -15,7 +15,6 @@ final class EditClipViewModel: ViewModel {
 
     struct State {
         var urlInputText: String
-        var isEmptyURLInput: Bool = false
         var isHiddenURLMetadataStackView = false
         var isHiddenURLValidationStackView = false
         var memoText: String
@@ -49,7 +48,6 @@ final class EditClipViewModel: ViewModel {
         switch mutation {
         case .updateURLInputText(let urlText):
             newState.urlInputText = urlText
-            newState.isEmptyURLInput = newState.urlInputText.isEmpty
             newState.isHiddenURLMetadataStackView = newState.urlInputText.isEmpty
             newState.isHiddenURLValidationStackView = newState.urlInputText.isEmpty
         case .updateMemo(let memoText):


### PR DESCRIPTION
## 📌 관련 이슈

close #50 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- [x] ViewModel-UI 바인딩
- [x] 불필요한 State 삭제
- [x] ViewModel init 구조 변경
- [x] ViewController init 수정(ViewModel 의존성 주입)

## 📌 구현 내역 스크린샷
| 실행 기기 | 스크린샷(또는 GIF) | 설명 |
| :-------------: | :----------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/0aebd340-36c1-4a7c-a14f-e2656ac3df0e"  width="250px"> | 클립 생성 버튼 누를 때? |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/7a0268c8-5674-406a-aaa3-10526a7914a7"  width="250px"> | Share Extension 또는 Toast Viewd에서 Push 또는 ClipDetailView에서 Push |

## 📌 참고 사항
Share Extension과 Toast View에서 EditClipView로 Push 되는 경우는 URL만 입력되어 Push되기 때문에 디폴트 파라미터로 구현
```
init(urlText: String = "", memoText: String = "") { }
```
