### PR TITLE
[Feat] CoreData Update, Delete 구현

### DIFF
--- a/Clipster/Clipster/Data/Error/CoreDataError.swift
+++ b/Clipster/Clipster/Data/Error/CoreDataError.swift
@@ -2,4 +2,5 @@ enum CoreDataError: Error {
     case entityNotFound
     case fetchFailed(String)
     case insertFailed(String)
+    case updateFailed(String)
 }

--- a/Clipster/Clipster/Data/Error/CoreDataError.swift
+++ b/Clipster/Clipster/Data/Error/CoreDataError.swift
@@ -3,4 +3,5 @@ enum CoreDataError: Error {
     case fetchFailed(String)
     case insertFailed(String)
     case updateFailed(String)
+    case deleteFailed(String)
 }

--- a/Clipster/Clipster/Data/Persistence/DefaultClipStorage.swift
+++ b/Clipster/Clipster/Data/Persistence/DefaultClipStorage.swift
@@ -105,6 +105,29 @@ final class DefaultClipStorage: ClipStorage {
         }
     }
 
+    func deleteClip(_ clip: Clip) -> Result<Void, CoreDataError> {
+        let request = ClipEntity.fetchRequest()
+        request.predicate = NSPredicate(format: "id == %@ AND deletedAt == nil", clip.id as CVarArg)
+        request.fetchLimit = 1
+
+        do {
+            guard let entity = try context.fetch(request).first else {
+                print("\(Self.self): ❌ Failed to delete: Entity not found")
+                return .failure(.entityNotFound)
+            }
+
+            entity.deletedAt = clip.deletedAt
+            entity.urlMetadata?.deletedAt = clip.urlMetadata.deletedAt
+
+            try context.save()
+            print("\(Self.self): ✅ Delete successfully")
+            return .success(())
+        } catch {
+            print("\(Self.self): ❌ Failed to delete: \(error.localizedDescription)")
+            return .failure(.updateFailed(error.localizedDescription))
+        }
+    }
+
     private func fetchFolderEntity(by id: UUID) -> FolderEntity? {
         let request = FolderEntity.fetchRequest()
         request.predicate = NSPredicate(format: "id == %@ AND deletedAt == nil", id as CVarArg)

--- a/Clipster/Clipster/Data/Protocol/Persistence/ClipStorage.swift
+++ b/Clipster/Clipster/Data/Protocol/Persistence/ClipStorage.swift
@@ -5,4 +5,5 @@ protocol ClipStorage {
     func fetchUnvisitedClips() -> Result<[ClipEntity], CoreDataError>
     func insertClip(_ clip: Clip) -> Result<Void, CoreDataError>
     func updateClip(_ clip: Clip) -> Result<Void, CoreDataError>
+    func deleteClip(_ clip: Clip) -> Result<Void, CoreDataError>
 }

--- a/Clipster/Clipster/Data/Protocol/Persistence/ClipStorage.swift
+++ b/Clipster/Clipster/Data/Protocol/Persistence/ClipStorage.swift
@@ -4,4 +4,5 @@ protocol ClipStorage {
     func fetchClip(by id: UUID) -> Result<ClipEntity, CoreDataError>
     func fetchUnvisitedClips() -> Result<[ClipEntity], CoreDataError>
     func insertClip(_ clip: Clip) -> Result<Void, CoreDataError>
+    func updateClip(_ clip: Clip) -> Result<Void, CoreDataError>
 }

--- a/Clipster/Clipster/Data/Protocol/Persistence/FolderStorage.swift
+++ b/Clipster/Clipster/Data/Protocol/Persistence/FolderStorage.swift
@@ -4,4 +4,5 @@ protocol FolderStorage {
     func fetchFolder(by id: UUID) -> Result<FolderEntity, CoreDataError>
     func fetchTopLevelFolders() -> Result<[FolderEntity], CoreDataError>
     func insertFolder(_ folder: Folder) -> Result<Void, CoreDataError>
+    func updateFolder(_ folder: Folder) -> Result<Void, CoreDataError>
 }

--- a/Clipster/Clipster/Data/Protocol/Persistence/FolderStorage.swift
+++ b/Clipster/Clipster/Data/Protocol/Persistence/FolderStorage.swift
@@ -5,4 +5,5 @@ protocol FolderStorage {
     func fetchTopLevelFolders() -> Result<[FolderEntity], CoreDataError>
     func insertFolder(_ folder: Folder) -> Result<Void, CoreDataError>
     func updateFolder(_ folder: Folder) -> Result<Void, CoreDataError>
+    func deleteFolder(_ folder: Folder) -> Result<Void, CoreDataError>
 }


### PR DESCRIPTION
## 📌 관련 이슈

close #14 
close #15 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

- ClipEntity Update 구현
- ClipEntity Delete 구현
- FolderEntity Update 구현
- FolderEntity Delete 구현

## 📌 참고 사항

슬랙에서 논의한 대로
1. CreatedAt, UpdatedAt, DeletedAt 기준 시간은 Domain Layer에서 갱신합니다.
2. Delete시, updatedAt은 갱신하지 않습니다.