### PR TITLE
[Feat] HomeView Long Press 시 UIMenu 표시

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -105,11 +105,13 @@ final class HomeView: UIView {
 }
 
 private extension HomeView {
-    private func createCollectionViewLayout() -> UICollectionViewLayout {
+    func createCollectionViewLayout() -> UICollectionViewLayout {
         let layout = UICollectionViewCompositionalLayout(
             sectionProvider: { [weak self] (index, _) -> NSCollectionLayoutSection? in
-                guard let self else { return nil }
-                guard let section = Section(rawValue: index) else { return nil }
+                guard let self,
+                      let section = Section(rawValue: index)
+                else { return nil }
+
                 return self.makeSectionLayout(for: section)
             },
             configuration: {
@@ -122,7 +124,7 @@ private extension HomeView {
         return layout
     }
 
-    private func makeSectionLayout(for section: Section) -> NSCollectionLayoutSection {
+    func makeSectionLayout(for section: Section) -> NSCollectionLayoutSection {
         let layoutSection: NSCollectionLayoutSection
 
         switch section {
@@ -138,7 +140,7 @@ private extension HomeView {
         return layoutSection
     }
 
-    private func makeClipSectionLayout() -> NSCollectionLayoutSection {
+    func makeClipSectionLayout() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
             heightDimension: .fractionalHeight(1.0)
@@ -160,7 +162,7 @@ private extension HomeView {
         return section
     }
 
-    private func makeFolderSectionLayout() -> NSCollectionLayoutSection {
+    func makeFolderSectionLayout() -> NSCollectionLayoutSection {
         let itemSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
             heightDimension: .fractionalHeight(1)
@@ -171,7 +173,7 @@ private extension HomeView {
             widthDimension: .fractionalWidth(1.0),
             heightDimension: .absolute(72)
         )
-        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
 
         let section = NSCollectionLayoutSection(group: group)
         section.interGroupSpacing = 8
@@ -180,7 +182,7 @@ private extension HomeView {
         return section
     }
 
-    private func makeHeaderItemLayout() -> NSCollectionLayoutBoundarySupplementaryItem {
+    func makeHeaderItemLayout() -> NSCollectionLayoutBoundarySupplementaryItem {
         let headerSize = NSCollectionLayoutSize(
             widthDimension: .fractionalWidth(1.0),
             heightDimension: .absolute(48)

--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -1,7 +1,16 @@
+import RxCocoa
+import RxSwift
 import SnapKit
 import UIKit
 
 final class HomeView: UIView {
+    enum Action {
+        case tap(IndexPath)
+        case info(IndexPath)
+        case edit(IndexPath)
+        case delete(IndexPath)
+    }
+
     enum Section: Int, CaseIterable {
         case clip
         case folder
@@ -11,6 +20,9 @@ final class HomeView: UIView {
         case clip(ClipCellDisplay)
         case folder(FolderCellDisplay)
     }
+
+    private let disposeBag = DisposeBag()
+    let action = PublishRelay<Action>()
 
     private var dataSource: UICollectionViewDiffableDataSource<Section, Item>?
 
@@ -188,6 +200,7 @@ private extension HomeView {
         setAttributes()
         setHierarchy()
         setConstraints()
+        setBindings()
     }
 
     func setAttributes() {
@@ -204,5 +217,12 @@ private extension HomeView {
             make.horizontalEdges.equalToSuperview()
             make.bottom.equalToSuperview()
         }
+    }
+
+    func setBindings() {
+        collectionView.rx.itemSelected
+            .map { Action.tap($0) }
+            .bind(to: action)
+            .disposed(by: disposeBag)
     }
 }

--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -177,7 +177,7 @@ private extension HomeView {
             elementKind: UICollectionView.elementKindSectionHeader,
             alignment: .top
         )
-        header.contentInsets = .init(top: 0, leading: 36, bottom: 0, trailing: 12)
+        header.contentInsets = .init(top: 0, leading: 12, bottom: 0, trailing: 0)
 
         return header
     }

--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -31,6 +31,7 @@ final class HomeView: UIView {
             frame: .zero,
             collectionViewLayout: createCollectionViewLayout()
         )
+        collectionView.delegate = self
         return collectionView
     }()
 
@@ -192,6 +193,54 @@ private extension HomeView {
         header.contentInsets = .init(top: 0, leading: 12, bottom: 0, trailing: 0)
 
         return header
+    }
+}
+
+extension HomeView: UICollectionViewDelegate {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        contextMenuConfigurationForItemAt indexPath: IndexPath,
+        point: CGPoint
+    ) -> UIContextMenuConfiguration? {
+        guard let item = dataSource?.itemIdentifier(for: indexPath) else { return nil }
+
+        return UIContextMenuConfiguration(
+            identifier: indexPath as NSCopying,
+            previewProvider: nil
+        ) { _ in
+            var actions: [UIAction] = []
+
+            switch item {
+            case .clip:
+                let info = UIAction(
+                    title: "상세정보",
+                    image: UIImage(systemName: "magnifyingglass")
+                ) { [weak self] _ in
+                    self?.action.accept(.info(indexPath))
+                }
+                actions.append(info)
+                fallthrough
+            case .folder:
+                let edit = UIAction(
+                    title: "편집",
+                    image: UIImage(systemName: "pencil")
+                ) { [weak self] _ in
+                    self?.action.accept(.edit(indexPath))
+                }
+
+                let delete = UIAction(
+                    title: "삭제",
+                    image: UIImage(systemName: "trash"),
+                    attributes: .destructive
+                ) { [weak self] _ in
+                    self?.action.accept(.delete(indexPath))
+                }
+
+                actions.append(contentsOf: [edit, delete])
+            }
+
+            return UIMenu(title: "", children: actions)
+        }
     }
 }
 


### PR DESCRIPTION
## 📌 관련 이슈
close #56 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- 셀을 길게 누르면 UIMenu가 표시되도록 구현

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/ae7f38c5-dc97-4a7e-ba60-65af88dbf0f6" width="250px"> |

## 📌 PR Point
- UIMenu가 표시되었다가 사라질 때 셀의 그림자가 깜빡이는 문제가 있습니다.
- 현재 원인을 찾지 못해 추후 수정 예정이며, 해결 방법을 아신다면 코멘트 부탁드립니다.

## 📌 참고 사항
- Swipe Action을 통한 삭제 기능은 list 스타일에서만 기본 지원됨
- 현재는 일반 Compositional Layout을 사용 중이라, 삭제 기능은 UIPanGestureRecognizer 또는 RxGesture 등을 활용해 커스텀 구현이 필요
- 구현하는데 시간이 많이 걸릴거 같아 이번 PR에는 스와이프 삭제기능을 포함하지 않았으며, 추후 별도 구현 예정


