### PR TITLE
[Feat] HomeViewModel Action, State, Route 바인딩

### DIFF
--- a/Clipster/Clipster/App/Source/SceneDelegate.swift
+++ b/Clipster/Clipster/App/Source/SceneDelegate.swift
@@ -10,7 +10,18 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = HomeViewController()
+        let fetchUnvisitedClipsUseCase = DefaultFetchUnvisitedClipsUseCase()
+        let fetchTopLevelFoldersUseCase = DefaultFetchTopLevelFoldersUseCase()
+        let deleteClipUseCase = DefaultDeleteClipUseCase()
+        let deleteFolderUseCase = DefaultDeleteFolderUseCase()
+        let homeViewModel = HomeViewModel(
+            fetchUnvisitedClipsUseCase: fetchUnvisitedClipsUseCase,
+            fetchTopLevelFoldersUseCase: fetchTopLevelFoldersUseCase,
+            deleteClipUseCase: deleteClipUseCase,
+            deleteFolderUseCase: deleteFolderUseCase
+        )
+        let homeVC = HomeViewController(homeviewModel: homeViewModel)
+        window?.rootViewController = UINavigationController(rootViewController: homeVC)
         window?.makeKeyAndVisible()
 
         window?.backgroundColor = .systemBackground

--- a/Clipster/Clipster/Domain/Protocol/UseCase/Clip/DeleteClipUseCase.swift
+++ b/Clipster/Clipster/Domain/Protocol/UseCase/Clip/DeleteClipUseCase.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 protocol DeleteClipUseCase {
-    func execute(id: UUID) async -> Result<Void, Error>
+    func execute(_ clip: Clip) async -> Result<Void, Error>
 }

--- a/Clipster/Clipster/Domain/Protocol/UseCase/Clip/DeleteClipUseCase.swift
+++ b/Clipster/Clipster/Domain/Protocol/UseCase/Clip/DeleteClipUseCase.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 protocol DeleteClipUseCase {
     func execute(_ clip: Clip) async -> Result<Void, Error>
 }

--- a/Clipster/Clipster/Domain/Protocol/UseCase/Folder/DeleteFolderUseCase.swift
+++ b/Clipster/Clipster/Domain/Protocol/UseCase/Folder/DeleteFolderUseCase.swift
@@ -1,0 +1,3 @@
+protocol DeleteFolderUseCase {
+    func execute(_ folder: Folder) async -> Result<Void, Error>
+}

--- a/Clipster/Clipster/Domain/Protocol/UseCase/Folder/FetchTopLevelFoldersUseCase.swift
+++ b/Clipster/Clipster/Domain/Protocol/UseCase/Folder/FetchTopLevelFoldersUseCase.swift
@@ -1,5 +1,5 @@
 import Foundation
 
-protocol FetchFolderUseCase {
+protocol FetchTopLevelFoldersUseCase {
     func execute(parentFolderID: UUID?) async -> Result<Folder, Error>
 }

--- a/Clipster/Clipster/Domain/UseCase/Clip/DefaultDeleteClipUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/Clip/DefaultDeleteClipUseCase.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 final class DefaultDeleteClipUseCase: DeleteClipUseCase {
-    func execute(id: UUID) async -> Result<Void, Error> {
+    func execute(_ clip: Clip) async -> Result<Void, Error> {
         .success(())
     }
 }

--- a/Clipster/Clipster/Domain/UseCase/Clip/DefaultDeleteClipUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/Clip/DefaultDeleteClipUseCase.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 final class DefaultDeleteClipUseCase: DeleteClipUseCase {
     func execute(_ clip: Clip) async -> Result<Void, Error> {
         .success(())

--- a/Clipster/Clipster/Domain/UseCase/Folder/DefaultDeleteFolderUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/Folder/DefaultDeleteFolderUseCase.swift
@@ -1,0 +1,5 @@
+final class DefaultDeleteFolderUseCase: DeleteFolderUseCase {
+    func execute(_ folder: Folder) async -> Result<Void, Error> {
+        .success(())
+    }
+}

--- a/Clipster/Clipster/Domain/UseCase/Folder/DefaultFetchTopLevelFoldersUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/Folder/DefaultFetchTopLevelFoldersUseCase.swift
@@ -4,7 +4,7 @@ enum DummyError: Error {
     case notImplemented
 }
 
-final class DefaultFetchFolderUseCase: FetchFolderUseCase {
+final class DefaultFetchTopLevelFoldersUseCase: FetchTopLevelFoldersUseCase {
     func execute(parentFolderID: UUID?) async -> Result<Folder, Error> {
         .failure(DummyError.notImplemented)
     }

--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -6,7 +6,7 @@ import UIKit
 final class HomeView: UIView {
     enum Action {
         case tap(IndexPath)
-        case info(IndexPath)
+        case detail(IndexPath)
         case edit(IndexPath)
         case delete(IndexPath)
     }
@@ -218,7 +218,7 @@ extension HomeView: UICollectionViewDelegate {
                     title: "상세정보",
                     image: UIImage(systemName: "magnifyingglass")
                 ) { [weak self] _ in
-                    self?.action.accept(.info(indexPath))
+                    self?.action.accept(.detail(indexPath))
                 }
                 actions.append(info)
                 fallthrough

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -1,7 +1,21 @@
+import RxCocoa
+import RxSwift
 import UIKit
 
 final class HomeViewController: UIViewController {
+    private let disposeBag = DisposeBag()
+
+    private let homeviewModel: HomeViewModel
     private let homeView = HomeView()
+
+    init(homeviewModel: HomeViewModel) {
+        self.homeviewModel = homeviewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func loadView() {
         view = homeView
@@ -12,19 +26,23 @@ final class HomeViewController: UIViewController {
         configure()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        homeviewModel.action.accept(.viewWillAppear)
+    }
+
     private func makeAddButtonMenu() -> UIMenu {
         let addFolderAction = UIAction(
             title: "폴더 추가",
             image: UIImage(systemName: "folder")
-        ) { _ in
-            print("폴더 추가 버튼 탭")
+        ) { [weak self] _ in
+            self?.homeviewModel.action.accept(.tapAddFolder)
         }
 
         let addClipAction = UIAction(
             title: "클립 추가",
             image: UIImage(systemName: "paperclip"),
-        ) { _ in
-            print("클립 추가 버튼 탭")
+        ) { [weak self] _ in
+            self?.homeviewModel.action.accept(.tapAddClip)
         }
 
         return UIMenu(title: "", children: [addFolderAction, addClipAction])
@@ -35,6 +53,7 @@ private extension HomeViewController {
     func configure() {
         setAttributes()
         setNavigationBarItems()
+        setBindings()
     }
 
     func setAttributes() {
@@ -45,8 +64,8 @@ private extension HomeViewController {
     func setNavigationBarItems() {
         let infoButton = UIBarButtonItem(
             image: UIImage(systemName: "info.circle"),
-            primaryAction: UIAction { _ in
-                print("라이센스 버튼 탭")
+            primaryAction: UIAction { [weak self] _ in
+                self?.homeviewModel.action.accept(.tapLicense)
             }
         )
 
@@ -57,5 +76,31 @@ private extension HomeViewController {
 
         navigationController?.navigationBar.tintColor = .label
         navigationItem.rightBarButtonItems = [infoButton, addButton]
+    }
+
+    func setBindings() {
+        homeView.action
+            .bind(with: self) { owner, action in
+                switch action {
+                case .tap(let indexPath):
+                    owner.homeviewModel.action.accept(.tapCell(indexPath))
+                case .detail(let indexPath):
+                    owner.homeviewModel.action.accept(.tapDetail(indexPath))
+                case .edit(let indexPath):
+                    owner.homeviewModel.action.accept(.tapEdit(indexPath))
+                case .delete(let indexPath):
+                    owner.homeviewModel.action.accept(.tapDelete(indexPath))
+                }
+            }
+            .disposed(by: disposeBag)
+
+        homeviewModel.state
+            .subscribe(with: self) { owner, state in
+                switch state {
+                case .homeDisplay(let homeDisplay):
+                    owner.homeView.setDisplay(homeDisplay)
+                }
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -27,6 +27,7 @@ final class HomeViewController: UIViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
         homeviewModel.action.accept(.viewWillAppear)
     }
 

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -95,7 +95,8 @@ private extension HomeViewController {
             .disposed(by: disposeBag)
 
         homeviewModel.state
-            .subscribe(with: self) { owner, state in
+            .asSignal()
+            .emit(with: self) { owner, state in
                 switch state {
                 case .homeDisplay(let homeDisplay):
                     owner.homeView.setDisplay(homeDisplay)
@@ -104,7 +105,8 @@ private extension HomeViewController {
             .disposed(by: disposeBag)
 
         homeviewModel.route
-            .subscribe(with: self) { _, route in
+            .asSignal()
+            .emit(with: self) { _, route in
                 switch route {
                 case .showAddClip:
                     print("클립 추가 화면 이동\n")

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -102,5 +102,33 @@ private extension HomeViewController {
                 }
             }
             .disposed(by: disposeBag)
+
+        homeviewModel.route
+            .subscribe(with: self) { _, route in
+                switch route {
+                case .showAddClip:
+                    print("클립 추가 화면 이동\n")
+                case .showAddFolder:
+                    print("폴더 추가 화면 이동\n")
+                case .showWebView(let url):
+                    print("웹 뷰")
+                    print("\(url)\n")
+                case .showFolder(let folder):
+                    print("폴더 화면 이동")
+                    print("\(folder)\n")
+                case .showDetailClip(let clip):
+                    print("클립 상세 화면 이동")
+                    print("\(clip)\n")
+                case .showEditClip(let clip):
+                    print("클립 편집 화면 이동")
+                    print("\(clip)\n")
+                case .showEditFolder(let folder):
+                    print("폴더 편집 화면 이동\n")
+                    print(folder)
+                case .showLicense:
+                    print("라이센스 화면 이동\n")
+                }
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
@@ -12,10 +12,25 @@ final class HomeViewModel {
         case homeDisplay(HomeDisplay)
     }
 
+    enum Route {
+        case showAddClip
+        case showAddFolder
+        case showWebView
+        case showFolder(Folder)
+        case showDetailClip(Clip)
+        case showEditClip(Clip)
+        case showEditFolder(Folder)
+        case showLicense
+    }
+
     private let disposeBag = DisposeBag()
 
     let action = PublishRelay<Action>()
     let state = PublishRelay<State>()
+    let route = PublishRelay<Route>()
+
+    private var unvisitedClips: [Clip] = []
+    private var folders: [Folder] = []
 
     private let fetchUnvisitedClipsUseCase: FetchUnvisitedClipsUseCase
     private let fetchFolderUseCase: FetchFolderUseCase
@@ -62,6 +77,8 @@ final class HomeViewModel {
 
     private func makeClipCellDisplays() async throws -> [ClipCellDisplay] {
         let clips = try await fetchUnvisitedClipsUseCase.execute().get()
+        unvisitedClips = clips
+
         return clips.map {
             ClipCellDisplay(
                 thumbnailImageURL: $0.urlMetadata.thumbnailImageURL,
@@ -74,6 +91,8 @@ final class HomeViewModel {
 
     private func makeFolderCellDisplays() async throws -> [FolderCellDisplay] {
         let folder = try await fetchFolderUseCase.execute(parentFolderID: nil).get()
+        folders = folder.folders
+
         return folder.folders.map {
             FolderCellDisplay(
                 title: $0.title,

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
@@ -82,8 +82,8 @@ final class HomeViewModel {
         }
     }
 
-    private func deleteClip(_ id: UUID) async {
-        let result = await deleteClipUseCase.execute(id: id)
+    private func deleteClip(_ clip: Clip) async {
+        let result = await deleteClipUseCase.execute(clip)
         switch result {
         case .success:
             await makeHomeDisplay()

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
@@ -9,7 +9,7 @@ final class HomeViewModel {
     }
 
     enum State {
-        case HomeDisplay(HomeDisplay)
+        case homeDisplay(HomeDisplay)
     }
 
     private let disposeBag = DisposeBag()
@@ -54,7 +54,7 @@ final class HomeViewModel {
                 unvitsedClips: clipsResult,
                 folders: foldersResult
             )
-            state.accept(.HomeDisplay(homeDisplay))
+            state.accept(.homeDisplay(homeDisplay))
         } catch {
             print(error)
         }

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
@@ -4,8 +4,14 @@ import RxSwift
 
 final class HomeViewModel {
     enum Action {
-        case makeHomeDisplay
-        case deleteClip(_ clipID: UUID)
+        case viewWillAppear
+        case tapAddClip
+        case tapAddFolder
+        case tapCell(IndexPath)
+        case tapDetail(IndexPath)
+        case tapEdit(IndexPath)
+        case tapDelete(IndexPath)
+        case tapLicense
     }
 
     enum State {
@@ -51,10 +57,22 @@ final class HomeViewModel {
         action
             .subscribe(with: self) { owner, action in
                 switch action {
-                case .makeHomeDisplay:
+                case .viewWillAppear:
                     Task { await owner.makeHomeDisplay() }
-                case .deleteClip(let id):
-                    Task { await owner.deleteClip(id) }
+                case .tapAddClip:
+                    print("클립 추가")
+                case .tapAddFolder:
+                    print("폴더 추가")
+                case .tapCell(let indexPath):
+                    print("tapCell \(indexPath)")
+                case .tapDetail(let indexPath):
+                    print("tapDetail \(indexPath)")
+                case .tapEdit(let indexPath):
+                    print("tapEdit \(indexPath)")
+                case .tapDelete(let indexPath):
+                    print("tapDelete \(indexPath)")
+                case .tapLicense:
+                    print("라이센스")
                 }
             }
             .disposed(by: disposeBag)

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
@@ -39,18 +39,18 @@ final class HomeViewModel {
     private var folders: [Folder] = []
 
     private let fetchUnvisitedClipsUseCase: FetchUnvisitedClipsUseCase
-    private let fetchFolderUseCase: FetchFolderUseCase
+    private let fetchTopLevelFoldersUseCase: FetchTopLevelFoldersUseCase
     private let deleteClipUseCase: DeleteClipUseCase
     private let deleteFolderUseCase: DeleteFolderUseCase
 
     init(
         fetchUnvisitedClipsUseCase: FetchUnvisitedClipsUseCase,
-        fetchFolderUseCase: FetchFolderUseCase,
+        fetchTopLevelFoldersUseCase: FetchTopLevelFoldersUseCase,
         deleteClipUseCase: DeleteClipUseCase,
         deleteFolderUseCase: DeleteFolderUseCase
     ) {
         self.fetchUnvisitedClipsUseCase = fetchUnvisitedClipsUseCase
-        self.fetchFolderUseCase = fetchFolderUseCase
+        self.fetchTopLevelFoldersUseCase = fetchTopLevelFoldersUseCase
         self.deleteClipUseCase = deleteClipUseCase
         self.deleteFolderUseCase = deleteFolderUseCase
         bind()
@@ -140,7 +140,7 @@ final class HomeViewModel {
     }
 
     private func makeFolderCellDisplays() async throws -> [FolderCellDisplay] {
-        let folder = try await fetchFolderUseCase.execute(parentFolderID: nil).get()
+        let folder = try await fetchTopLevelFoldersUseCase.execute(parentFolderID: nil).get()
         folders = folder.folders
 
         return folder.folders.map {


### PR DESCRIPTION
## 📌 관련 이슈
close #59 
  
## 📌 PR 유형
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- 화면이동을 담당할 Route 열거형 추가
- 각 Action에 맞는 로직 추가
- DeleteUseCase 추가 및 수정

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| 클립 관련 액션 | <img src="https://github.com/user-attachments/assets/cab9ebd8-a6ab-486f-a506-1cd98a6cb3db" width="500px"> |
| 폴더 및 라이센스 관련 액션 | <img src="https://github.com/user-attachments/assets/78150bd5-9090-4f02-88b1-634598cb931d" width="500px"> |

## 📌 PR Point
- 화면이동을 위해 Route도 기존의 Action, State와 동일하게 열거형으로 생성(추후 합의)
- 각 화면이동에 필요한 데이터 타입이 적절한지

## 📌 참고 사항
- VM에서 action을 수신했을 때의 Logging은 다음 PR때 추가하겠습니다.
- 병합되지 않은 커밋이 PR에 잡히지 않게 하기 위하여 base를 이전 브랜치로 지정했습니다. 이전 브랜치 병합 후 수정하겠습니다.