### PR TITLE
[Feat] URLMetadata 파싱 구현

### DIFF
--- a/Clipster/Clipster/Data/DTO/ParsedURLMetadataDTO.swift
+++ b/Clipster/Clipster/Data/DTO/ParsedURLMetadataDTO.swift
@@ -3,7 +3,7 @@ import Foundation
 struct ParsedURLMetadataDTO {
     var url: URL
     var title: String
-    var thumbnailImage: String
+    var thumbnailImageURL: String
 }
 
 extension ParsedURLMetadataDTO {
@@ -11,7 +11,7 @@ extension ParsedURLMetadataDTO {
         ParsedURLMetadata(
             url: url,
             title: title,
-            thumbnailImage: URL(string: thumbnailImage)
+            thumbnailImageURL: URL(string: thumbnailImageURL)
         )
     }
 }

--- a/Clipster/Clipster/Data/DTO/ParsedURLMetadataDTO.swift
+++ b/Clipster/Clipster/Data/DTO/ParsedURLMetadataDTO.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+struct ParsedURLMetadataDTO {
+    var url: URL
+    var title: String
+    var thumbnailImage: String
+}
+
+extension ParsedURLMetadataDTO {
+    func toEntity() -> ParsedURLMetadata {
+        ParsedURLMetadata(
+            url: url,
+            title: title,
+            thumbnailImage: URL(string: thumbnailImage)
+        )
+    }
+}

--- a/Clipster/Clipster/Data/Repository/URLMetadata/DefaultURLMetadataRepository.swift
+++ b/Clipster/Clipster/Data/Repository/URLMetadata/DefaultURLMetadataRepository.swift
@@ -24,7 +24,7 @@ private extension DefaultURLMetadataRepository {
         ParsedURLMetadataDTO(
             url: url,
             title: extractMetaContent(html: html, property: "og:title") ?? "",
-            thumbnailImage: extractMetaContent(html: html, property: "og:image") ?? ""
+            thumbnailImageURL: extractMetaContent(html: html, property: "og:image") ?? ""
         )
     }
 

--- a/Clipster/Clipster/Data/Repository/URLMetadata/DefaultURLMetadataRepository.swift
+++ b/Clipster/Clipster/Data/Repository/URLMetadata/DefaultURLMetadataRepository.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+final class DefaultURLMetadataRepository: URLMetadataRepository {
+    func execute(url: URL) async -> Result<ParsedURLMetadata, any Error> {
+        do {
+            let (data, response) = try await URLSession.shared.data(from: url)
+
+            guard let httpResponse = response as? HTTPURLResponse,
+                  (200..<300).contains(httpResponse.statusCode) else {
+                return .failure(URLError(.badServerResponse))
+            }
+            let html = String(data: data, encoding: .utf8)
+            let urlMetadata = try parseHTML(url: url, html: html ?? "")
+            return .success(urlMetadata.toEntity())
+        } catch {
+            print(error)
+            return .failure(error)
+        }
+    }
+}
+
+private extension DefaultURLMetadataRepository {
+    func parseHTML(url: URL, html: String) throws -> ParsedURLMetadataDTO {
+        ParsedURLMetadataDTO(
+            url: url,
+            title: extractMetaContent(html: html, property: "og:title") ?? "",
+            thumbnailImage: extractMetaContent(html: html, property: "og:image") ?? ""
+        )
+    }
+
+    func extractMetaContent(html: String, property: String) -> String? {
+        let pattern = "<meta[^>]*property=[\"']\(property)[\"'][^>]*content=[\"']([^\"']*)[\"'][^>]*>"
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive) else {
+            return nil
+        }
+
+        let range = NSRange(html.startIndex..., in: html)
+        guard let match = regex.firstMatch(in: html, options: [], range: range),
+              let contentRange = Range(match.range(at: 1), in: html) else {
+            return nil
+        }
+
+        return String(html[contentRange])
+    }
+}

--- a/Clipster/Clipster/Domain/Entity/ParsedURLMetadata.swift
+++ b/Clipster/Clipster/Domain/Entity/ParsedURLMetadata.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct ParsedURLMetadata {
+    var url: URL
+    var title: String
+    var thumbnailImage: URL?
+}

--- a/Clipster/Clipster/Domain/Entity/ParsedURLMetadata.swift
+++ b/Clipster/Clipster/Domain/Entity/ParsedURLMetadata.swift
@@ -3,5 +3,5 @@ import Foundation
 struct ParsedURLMetadata {
     var url: URL
     var title: String
-    var thumbnailImage: URL?
+    var thumbnailImageURL: URL?
 }

--- a/Clipster/Clipster/Domain/Protocol/Repository/URLMetadata/URLMetadataRepository.swift
+++ b/Clipster/Clipster/Domain/Protocol/Repository/URLMetadata/URLMetadataRepository.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol URLMetadataRepository {
+    func execute(url: URL) async -> Result<ParsedURLMetadata, Error>
+}

--- a/Clipster/Clipster/Domain/Protocol/UseCase/URLMetadata/ParseURLMetadataUseCase.swift
+++ b/Clipster/Clipster/Domain/Protocol/UseCase/URLMetadata/ParseURLMetadataUseCase.swift
@@ -1,0 +1,3 @@
+protocol ParseURLMetadataUseCase {
+    func execute(urlString: String) async -> Result<ParsedURLMetadata, Error>
+}

--- a/Clipster/Clipster/Domain/UseCase/URLMetadata/DefaultParseURLMetadataUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/URLMetadata/DefaultParseURLMetadataUseCase.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+final class DefaultParseURLMetadataUseCase: ParseURLMetadataUseCase {
+    let repository: URLMetadataRepository
+
+    init(repository: URLMetadataRepository) {
+        self.repository = repository
+    }
+
+    func execute(urlString: String) async -> Result<ParsedURLMetadata, Error> {
+        guard let url = URL(string: urlString) else {
+            return .failure(URLError(.badURL))
+        }
+        return await repository.execute(url: url)
+    }
+}

--- a/Clipster/Clipster/Presentation/Model/URLMetadataDisplay.swift
+++ b/Clipster/Clipster/Presentation/Model/URLMetadataDisplay.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-struct URLMetadataDisplay {
+struct URLMetadataDisplay: Hashable {
     let url: URL
     let title: String
-    let thumbnailImageURL: URL
+    let thumbnailImageURL: URL?
 }


### PR DESCRIPTION
## 📌 관련 이슈

close #58 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- URLMetadata 파싱 로직 구현
- URLMetadataDisplay에서 thumbnailImageURL 타입 변경

## 📌 PR Point
종종 og: image가 없는 경우도 있어 thumbnailImageURL을 옵셔널 타입으로 수정하였습니다.
```swift
ParsedURLMetadataDTO(
    ...
    thumbnailImage: extractMetaContent(html: html, property: "og:image") ?? ""
)
```