### PR TITLE
[Feat] 내비게이션 공통 컴포넌트 구현

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Common/Button/AddButton.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/Button/AddButton.swift
@@ -1,0 +1,23 @@
+import UIKit
+
+final class AddButton: UIButton {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
+
+private extension AddButton {
+    func configure() {
+        setAttributes()
+    }
+
+    func setAttributes() {
+        setImage(UIImage(systemName: "plus"), for: .normal)
+        tintColor = .label
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/Common/Button/EditButton.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/Button/EditButton.swift
@@ -1,0 +1,23 @@
+import UIKit
+
+final class EditButton: UIButton {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
+
+private extension EditButton {
+    func configure() {
+        setAttributes()
+    }
+
+    func setAttributes() {
+        setImage(UIImage(systemName: "applepencil"), for: .normal)
+        tintColor = .label
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/Common/Button/InfoButton.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/Button/InfoButton.swift
@@ -1,0 +1,23 @@
+import UIKit
+
+final class InfoButton: UIButton {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
+
+private extension InfoButton {
+    func configure() {
+        setAttributes()
+    }
+
+    func setAttributes() {
+        setImage(UIImage(systemName: "info.circle"), for: .normal)
+        tintColor = .label
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/Common/Button/SaveButton.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/Button/SaveButton.swift
@@ -1,0 +1,35 @@
+import UIKit
+
+final class SaveButton: UIButton {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
+
+private extension SaveButton {
+    func configure() {
+        setAttributes()
+    }
+
+    func setAttributes() {
+        let normalFont = UIFont.systemFont(ofSize: 14, weight: .bold)
+        let disabledFont = UIFont.systemFont(ofSize: 14, weight: .medium)
+
+        let normalAttributes: [NSAttributedString.Key: Any] = [
+            .font: normalFont,
+            .foregroundColor: UIColor.systemBlue
+        ]
+        let disabledAttributes: [NSAttributedString.Key: Any] = [
+            .font: disabledFont,
+            .foregroundColor: UIColor.systemGray
+        ]
+
+        setAttributedTitle(NSAttributedString(string: "저장", attributes: normalAttributes), for: .normal)
+        setAttributedTitle(NSAttributedString(string: "저장", attributes: disabledAttributes), for: .disabled)
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/Common/View/BackButtonView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/View/BackButtonView.swift
@@ -1,0 +1,57 @@
+import RxCocoa
+import UIKit
+
+final class BackButtonView: UIView {
+    private let backButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "chevron.left"), for: .normal)
+        button.tintColor = .label
+        return button
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 18, weight: .semibold)
+        label.textColor = .label
+        return label
+    }()
+
+    var tap: ControlEvent<Void> { backButton.rx.tap }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    func setDisplay(_ title: String) {
+        titleLabel.text = title
+    }
+}
+
+private extension BackButtonView {
+    func configure() {
+        setHierarchy()
+        setConstraints()
+    }
+
+    func setHierarchy() {
+        [backButton, titleLabel]
+            .forEach { addSubview($0) }
+    }
+
+    func setConstraints() {
+        backButton.snp.makeConstraints { make in
+            make.leading.centerY.equalToSuperview()
+            make.size.equalTo(32)
+        }
+
+        titleLabel.snp.makeConstraints { make in
+            make.leading.equalTo(backButton.snp.trailing)
+            make.centerY.trailing.equalToSuperview()
+        }
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

close #62 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

내비게이션 바에 사용되는 공통 버튼 구현
- 뒤로가기 뷰(버튼, 레이블)
- 수정 버튼
- 추가 버튼
- 정보 버튼
- 저장 버튼

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/941b821c-5e99-4625-8064-fb65e61d280f" width="250px"> |

## 📌 참고 사항

1. 우선은 피그마에 사용된 이미지가 아닌 SF Symbol로 작업했습니다.
   후에 수정될 필요가 있을 수도 있습니다.
3. 구현이 간단함에도 굳이 공통 컴포넌트로 분리한 이유는 만약 디자인 변경사항이 생겼을 경우에 수정을 편하게 하기 위함입니다.
   혹시 필요가 없다고 생각하시면, 이 PR은 병합없이 닫겠습니다.
   편하게 의견 부탁드려요.
