### PR TITLE
[Feat] EditClipView UI 바인딩

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Common/StackView/URLMetadataStackView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/StackView/URLMetadataStackView.swift
@@ -95,3 +95,21 @@ private extension URLMetadataStackView {
         }
     }
 }
+
+extension URLMetadataStackView {
+    func setHiddenAnimated(_ hidden: Bool, duration: TimeInterval = 0.25) {
+        if hidden {
+            UIView.animate(withDuration: duration) {
+                self.alpha = 0
+                self.isHidden = true
+            }
+        } else {
+            self.isHidden = false
+            self.alpha = 0
+            UIView.animate(withDuration: duration) {
+                self.alpha = 1
+                self.superview?.layoutIfNeeded()
+            }
+        }
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/EditClip/Subview/StackView/URLValidationStackView.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Subview/StackView/URLValidationStackView.swift
@@ -53,3 +53,21 @@ private extension URLValidationStackView {
         }
     }
 }
+
+extension URLValidationStackView {
+    func setHiddenAnimated(_ hidden: Bool, duration: TimeInterval = 0.25) {
+        if hidden {
+            UIView.animate(withDuration: duration) {
+                self.alpha = 0
+                self.isHidden = true
+            }
+        } else {
+            self.isHidden = false
+            self.alpha = 0
+            UIView.animate(withDuration: duration) {
+                self.alpha = 1
+                self.superview?.layoutIfNeeded()
+            }
+        }
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/EditClip/Subview/View/EditClipView.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Subview/View/EditClipView.swift
@@ -8,6 +8,7 @@ final class EditClipView: UIView {
         button.setTitleColor(.tintColor, for: .normal)
         button.setTitleColor(.lightGray, for: .disabled)
         button.frame = .init(x: 0, y: 0, width: 44, height: 44)
+        button.isEnabled = false
         return button
     }()
 

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -120,5 +120,15 @@ private extension EditClipViewController {
             .asDriver(onErrorDriveWith: .empty())
             .drive(editClipView.urlValidationStacKView.statusLabel.rx.text)
             .disposed(by: disposeBag)
+
+        viewModel.state
+            .map(\.urlMetadata)
+            .compactMap { $0 }
+            .distinctUntilChanged()
+            .asDriver(onErrorDriveWith: .empty())
+            .drive { [weak self] urlMetadataDisplay in
+                self?.editClipView.urlMetadataStackView.setDisplay(model: urlMetadataDisplay)
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -68,14 +68,18 @@ private extension EditClipViewController {
             .map(\.isHiddenURLMetadataStackView)
             .distinctUntilChanged()
             .asDriver(onErrorDriveWith: .empty())
-            .drive(editClipView.urlMetadataStackView.rx.isHidden)
+            .drive { [weak self] isHidden in
+                self?.editClipView.urlMetadataStackView.setHiddenAnimated(isHidden)
+            }
             .disposed(by: disposeBag)
 
         viewModel.state
             .map(\.isHiddenURLValidationStackView)
             .distinctUntilChanged()
             .asDriver(onErrorDriveWith: .empty())
-            .drive(editClipView.urlValidationStacKView.rx.isHidden)
+            .drive { [weak self] isHidden in
+                self?.editClipView.urlValidationStacKView.setHiddenAnimated(isHidden)
+            }
             .disposed(by: disposeBag)
 
         editClipView.memoTextView

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -24,6 +24,7 @@ final class EditClipViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configure()
+        hideKeyboardWhenTappedBackground()
     }
 }
 

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -130,5 +130,17 @@ private extension EditClipViewController {
                 self?.editClipView.urlMetadataStackView.setDisplay(model: urlMetadataDisplay)
             }
             .disposed(by: disposeBag)
+
+        Observable.combineLatest(
+            viewModel.state.map(\.memoText),
+            viewModel.state.map(\.isURLValid),
+        )
+        .map { memoText, isURLValid in
+            !memoText.isEmpty && isURLValid
+        }
+        .distinctUntilChanged()
+        .asDriver(onErrorDriveWith: .empty())
+        .drive(editClipView.saveButton.rx.isEnabled)
+        .disposed(by: disposeBag)
     }
 }

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
@@ -12,6 +12,7 @@ final class EditClipViewModel: ViewModel {
         case updateURLInputText(String)
         case updateMemo(String)
         case updateValidURL(Bool)
+        case updateURLMetadata(URLMetadataDisplay?)
     }
 
     struct State {
@@ -23,6 +24,7 @@ final class EditClipViewModel: ViewModel {
         var isURLValid = false
         var urlValidationImageName: String = ""
         var urlValidationLabelText: String = ""
+        var urlMetadata: URLMetadataDisplay?
     }
 
     var state: BehaviorRelay<State>
@@ -30,11 +32,13 @@ final class EditClipViewModel: ViewModel {
     var disposeBag = DisposeBag()
 
     private let checkURLValidityUseCase: CheckURLValidityUseCase
+    private let parseURLMetadataUseCase: ParseURLMetadataUseCase
 
     init(
         urlText: String = "",
         memoText: String = "",
-        checkURLValidityUseCase: CheckURLValidityUseCase
+        checkURLValidityUseCase: CheckURLValidityUseCase,
+        parseURLMetadataUseCase: ParseURLMetadataUseCase
     ) {
         state = BehaviorRelay(value: State(
             urlInputText: urlText,
@@ -42,6 +46,7 @@ final class EditClipViewModel: ViewModel {
             memoLimit: "\(memoText)/100"
         ))
         self.checkURLValidityUseCase = checkURLValidityUseCase
+        self.parseURLMetadataUseCase = parseURLMetadataUseCase
         bind()
     }
 
@@ -53,8 +58,13 @@ final class EditClipViewModel: ViewModel {
                 .fromAsync {
                     try await self.checkURLValidityUseCase.execute(urlString: urlText).get()
                 }
-                .map { Mutation.updateValidURL($0) }
-                .catchAndReturn(.updateValidURL(false))
+                .map { .updateValidURL($0) }
+                .catchAndReturn(.updateValidURL(false)),
+                .fromAsync {
+                    try await self.parseURLMetadataUseCase.execute(urlString: urlText).get()
+                }
+                .map { .updateURLMetadata(self.toURLMetaDisplay(entity: $0)) }
+                .catchAndReturn(.updateURLMetadata(nil))
             )
         case .editMomo(let memoText):
             return .just(.updateMemo(memoText))
@@ -66,8 +76,9 @@ final class EditClipViewModel: ViewModel {
         switch mutation {
         case .updateURLInputText(let urlText):
             newState.urlInputText = urlText
-            newState.isHiddenURLMetadataStackView = newState.urlInputText.isEmpty
-            newState.isHiddenURLValidationStackView = newState.urlInputText.isEmpty
+            if urlText.isEmpty {
+                newState.isHiddenURLValidationStackView = true
+            }
         case .updateMemo(let memoText):
             newState.memoText = memoText
             newState.memoLimit = "\(memoText.count)/100"
@@ -75,8 +86,24 @@ final class EditClipViewModel: ViewModel {
             newState.isURLValid = result
             newState.urlValidationImageName = result ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
             newState.urlValidationLabelText = result ? "올바른 URL 입니다." : "올바르지 않은 URL 입니다."
+            if !state.urlInputText.isEmpty {
+                newState.isHiddenURLValidationStackView = false
+            }
+        case .updateURLMetadata(let urlMetaDisplay):
+            newState.urlMetadata = urlMetaDisplay
+            newState.isHiddenURLMetadataStackView = urlMetaDisplay == nil
         }
         return newState
+    }
+}
+
+private extension EditClipViewModel {
+    func toURLMetaDisplay(entity: ParsedURLMetadata) -> URLMetadataDisplay {
+        URLMetadataDisplay(
+            url: entity.url,
+            title: entity.title,
+            thumbnailImageURL: entity.thumbnailImageURL
+        )
     }
 }
 

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
@@ -16,8 +16,8 @@ final class EditClipViewModel: ViewModel {
 
     struct State {
         var urlInputText: String
-        var isHiddenURLMetadataStackView = false
-        var isHiddenURLValidationStackView = false
+        var isHiddenURLMetadataStackView = true
+        var isHiddenURLValidationStackView = true
         var memoText: String
         var memoLimit: String
         var isURLValid = false

--- a/Clipster/Clipster/Presentation/Util/Extension/ViewController+Extension.swift
+++ b/Clipster/Clipster/Presentation/Util/Extension/ViewController+Extension.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+extension UIViewController {
+    func hideKeyboardWhenTappedBackground() {
+         let tapEvent = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+         tapEvent.cancelsTouchesInView = false
+         view.addGestureRecognizer(tapEvent)
+    }
+
+    @objc func dismissKeyboard() {
+        view.endEditing(true)
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈

close #83 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- 저장 버튼 활성화 여부 바인딩
- URLMetadata 파싱 관련 로직 적용
- URLMetadataStackView, URLValidationStackView 애니메이션 추가
- 키보드 내리기 Extension 추가


## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/c610c3a2-9da9-42a3-b676-b2c4e0e5dc5e" width="250px"> |

## 📌 참고 사항

키보드 내리기 Extension 작성과 함께 적용하였기 때문에 현재 PR에 포함하여 올렸습니다.
