### PR TITLE
[Feat] Section Header View 전체보기 버튼 추가 및 바인딩

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Common/Cell/SectionHeaderView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/Cell/SectionHeaderView.swift
@@ -1,11 +1,26 @@
+import RxRelay
+import RxSwift
 import SnapKit
 import UIKit
 
 final class SectionHeaderView: UICollectionReusableView {
+    let showAllTapped = PublishRelay<Void>()
+    private let disposeBag = DisposeBag()
+
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 16, weight: .semibold)
         return label
+    }()
+
+    private let showAllButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("전체보기", for: .normal)
+        button.setTitleColor(.systemGray, for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 14, weight: .semibold)
+        button.titleLabel?.textAlignment = .center
+        button.isHidden = true
+        return button
     }()
 
     override init(frame: CGRect) {
@@ -20,21 +35,42 @@ final class SectionHeaderView: UICollectionReusableView {
     func setTitle(_ title: String) {
         titleLabel.text = title
     }
+
+    func setShowAllButtonVisible(_ isVisible: Bool) {
+        showAllButton.isHidden = !isVisible
+    }
 }
 
 private extension SectionHeaderView {
     func configure() {
         setHierarchy()
         setConstraints()
+        setBindings()
     }
 
     func setHierarchy() {
-        addSubview(titleLabel)
+        [
+            titleLabel,
+            showAllButton
+        ].forEach { addSubview($0) }
     }
 
     func setConstraints() {
-        titleLabel.snp.makeConstraints {
-            $0.edges.equalToSuperview()
+        titleLabel.snp.makeConstraints { make in
+            make.verticalEdges.equalToSuperview()
+            make.leading.equalToSuperview()
         }
+
+        showAllButton.snp.makeConstraints { make in
+            make.verticalEdges.equalToSuperview()
+            make.leading.greaterThanOrEqualTo(titleLabel).offset(12)
+            make.trailing.equalToSuperview()
+        }
+    }
+
+    func setBindings() {
+        showAllButton.rx.tap
+            .bind(to: showAllTapped)
+            .disposed(by: disposeBag)
     }
 }

--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -9,6 +9,7 @@ final class HomeView: UIView {
         case detail(IndexPath)
         case edit(IndexPath)
         case delete(IndexPath)
+        case showAllClips
     }
 
     enum Section: Int, CaseIterable {
@@ -78,6 +79,12 @@ final class HomeView: UIView {
             switch section {
             case .clip:
                 header.setTitle("방문하지 않은 클립")
+                header.setShowAllButtonVisible(true)
+
+                header.showAllTapped
+                    .map { Action.showAllClips }
+                    .bind(to: self.action)
+                    .disposed(by: self.disposeBag)
             case .folder:
                 header.setTitle("폴더")
             }

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -85,7 +85,7 @@ private extension HomeViewController {
                 case .delete(let indexPath):
                     owner.homeviewModel.action.accept(.tapDelete(indexPath))
                 case .showAllClips:
-                    owner.homeviewModel.action.accept(.tapShowALlClips)
+                    owner.homeviewModel.action.accept(.tapShowAllClips)
                 }
             }
             .disposed(by: disposeBag)

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -84,6 +84,8 @@ private extension HomeViewController {
                     owner.homeviewModel.action.accept(.tapEdit(indexPath))
                 case .delete(let indexPath):
                     owner.homeviewModel.action.accept(.tapDelete(indexPath))
+                case .showAllClips:
+                    owner.homeviewModel.action.accept(.tapShowALlClips)
                 }
             }
             .disposed(by: disposeBag)
@@ -121,6 +123,9 @@ private extension HomeViewController {
                 case .showEditFolder(let folder):
                     print("폴더 편집 화면 이동\n")
                     print(folder)
+                case .showUnvisitedClipList(let clips):
+                    print("읽지 않은 클립 화면 이동")
+                    print("\(clips)\n")
                 }
             }
             .disposed(by: disposeBag)

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -102,7 +102,7 @@ private extension HomeViewController {
 
         homeviewModel.route
             .asSignal()
-            .emit(with: self) { _, route in
+            .emit(with: self) { owner, route in
                 switch route {
                 case .showAddClip:
                     print("클립 추가 화면 이동\n")
@@ -126,6 +126,8 @@ private extension HomeViewController {
                 case .showUnvisitedClipList(let clips):
                     print("읽지 않은 클립 화면 이동")
                     print("\(clips)\n")
+                    let vc = UnvisitedClipListViewController()
+                    owner.navigationController?.pushViewController(vc, animated: true)
                 }
             }
             .disposed(by: disposeBag)

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -63,20 +63,13 @@ private extension HomeViewController {
     }
 
     func setNavigationBarItems() {
-        let infoButton = UIBarButtonItem(
-            image: UIImage(systemName: "info.circle"),
-            primaryAction: UIAction { [weak self] _ in
-                self?.homeviewModel.action.accept(.tapLicense)
-            }
-        )
-
         let addButton = UIBarButtonItem(
             systemItem: .add,
             menu: makeAddButtonMenu()
         )
 
         navigationController?.navigationBar.tintColor = .label
-        navigationItem.rightBarButtonItems = [infoButton, addButton]
+        navigationItem.rightBarButtonItem = addButton
     }
 
     func setBindings() {
@@ -128,8 +121,6 @@ private extension HomeViewController {
                 case .showEditFolder(let folder):
                     print("폴더 편집 화면 이동\n")
                     print(folder)
-                case .showLicense:
-                    print("라이센스 화면 이동\n")
                 }
             }
             .disposed(by: disposeBag)

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
@@ -11,6 +11,7 @@ final class HomeViewModel {
         case tapDetail(IndexPath)
         case tapEdit(IndexPath)
         case tapDelete(IndexPath)
+        case tapShowALlClips
     }
 
     enum State {
@@ -25,6 +26,7 @@ final class HomeViewModel {
         case showDetailClip(Clip)
         case showEditClip(Clip)
         case showEditFolder(Folder)
+        case showUnvisitedClipList([Clip])
     }
 
     private let disposeBag = DisposeBag()
@@ -72,6 +74,8 @@ final class HomeViewModel {
                     }
                 case .tapDelete(let indexPath):
                     owner.handleTapDelete(at: indexPath)
+                case .tapShowALlClips:
+                    owner.route.accept(.showUnvisitedClipList(self.unvisitedClips))
                 }
             }
             .disposed(by: disposeBag)

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
@@ -11,7 +11,7 @@ final class HomeViewModel {
         case tapDetail(IndexPath)
         case tapEdit(IndexPath)
         case tapDelete(IndexPath)
-        case tapShowALlClips
+        case tapShowAllClips
     }
 
     enum State {
@@ -74,7 +74,7 @@ final class HomeViewModel {
                     }
                 case .tapDelete(let indexPath):
                     owner.handleTapDelete(at: indexPath)
-                case .tapShowALlClips:
+                case .tapShowAllClips:
                     owner.route.accept(.showUnvisitedClipList(self.unvisitedClips))
                 }
             }

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
@@ -11,7 +11,6 @@ final class HomeViewModel {
         case tapDetail(IndexPath)
         case tapEdit(IndexPath)
         case tapDelete(IndexPath)
-        case tapLicense
     }
 
     enum State {
@@ -26,7 +25,6 @@ final class HomeViewModel {
         case showDetailClip(Clip)
         case showEditClip(Clip)
         case showEditFolder(Folder)
-        case showLicense
     }
 
     private let disposeBag = DisposeBag()
@@ -74,8 +72,6 @@ final class HomeViewModel {
                     }
                 case .tapDelete(let indexPath):
                     owner.handleTapDelete(at: indexPath)
-                case .tapLicense:
-                    owner.route.accept(.showLicense)
                 }
             }
             .disposed(by: disposeBag)

--- a/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewController/UnvisitedClipListViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewController/UnvisitedClipListViewController.swift
@@ -1,0 +1,4 @@
+import UIKit
+
+final class UnvisitedClipListViewController: UIViewController {
+}


### PR DESCRIPTION
## 📌 관련 이슈
close #92 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/ad6b78f2-7a30-43bb-a7c8-99bddf614c3e" width="250px"> |

## 📌 변경 사항 및 이유
- 라이센스 버튼 제거
- 읽지 않은 클립 뷰로 이동하기 위한 버튼을 추가
- 버튼 탭 시 화면 이동

## 📌 PR Point
- 기본값으로 Hidden 처리 및 setShowAllButtonVisible 메소드를 통해 필요할때만 보여지도록 구현