### PR TITLE
[Feat] 방문하지 않은 클립 리스트 뷰 UI 구현

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -29,6 +29,12 @@ final class HomeViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         homeviewModel.action.accept(.viewWillAppear)
+        navigationController?.navigationBar.prefersLargeTitles = true
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        navigationController?.navigationBar.prefersLargeTitles = false
     }
 
     private func makeAddButtonMenu() -> UIMenu {
@@ -59,7 +65,6 @@ private extension HomeViewController {
 
     func setAttributes() {
         title = "Clipster"
-        navigationController?.navigationBar.prefersLargeTitles = true
     }
 
     func setNavigationBarItems() {

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -131,7 +131,7 @@ private extension HomeViewController {
                 case .showUnvisitedClipList(let clips):
                     print("읽지 않은 클립 화면 이동")
                     print("\(clips)\n")
-                    let vc = UnvisitedClipListViewController()
+                    let vc = UnvisitedClipListViewController(clips: clips)
                     owner.navigationController?.pushViewController(vc, animated: true)
                 }
             }

--- a/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/SubView/View/UnvisitedClipListView.swift
+++ b/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/SubView/View/UnvisitedClipListView.swift
@@ -1,0 +1,100 @@
+import SnapKit
+import UIKit
+
+final class UnvisitedClipListView: UIView {
+    typealias Section = Int
+    typealias Item = ClipCellDisplay
+
+    private var dataSource: UICollectionViewDiffableDataSource<Section, Item>?
+
+    private lazy var collectionView: UICollectionView = {
+        let collectionView = UICollectionView(
+            frame: .zero,
+            collectionViewLayout: createCollectionViewLayout()
+        )
+        return collectionView
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+        configureDataSource()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func configureDataSource() {
+        let clipCellRegistration = UICollectionView.CellRegistration<ClipCell, ClipCellDisplay> { cell, _, item in
+            cell.setDisplay(item)
+        }
+
+        dataSource = .init(collectionView: collectionView) { collectionView, indexPath, item in
+            collectionView.dequeueConfiguredReusableCell(
+                using: clipCellRegistration,
+                for: indexPath,
+                item: item
+            )
+        }
+    }
+
+    func setDisplay(_ display: [ClipCellDisplay]) {
+        var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
+        snapshot.appendSections([0])
+        snapshot.appendItems(display, toSection: 0)
+        dataSource?.apply(snapshot)
+    }
+}
+
+private extension UnvisitedClipListView {
+    func createCollectionViewLayout() -> UICollectionViewLayout {
+        let layout = UICollectionViewCompositionalLayout { _, _ in
+            let itemSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .fractionalHeight(1.0)
+            )
+            let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+            let groupSize = NSCollectionLayoutSize(
+                widthDimension: .fractionalWidth(1.0),
+                heightDimension: .absolute(72)
+            )
+            let group = NSCollectionLayoutGroup.vertical(
+                layoutSize: groupSize,
+                subitems: [item]
+            )
+
+            let section = NSCollectionLayoutSection(group: group)
+            section.interGroupSpacing = 8
+            section.contentInsets = NSDirectionalEdgeInsets(top: 24, leading: 24, bottom: 0, trailing: 24)
+            return section
+        }
+
+        return layout
+    }
+}
+
+private extension UnvisitedClipListView {
+    func configure() {
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+    }
+
+    func setAttributes() {
+        backgroundColor = .systemBackground
+    }
+
+    func setHierarchy() {
+        addSubview(collectionView)
+    }
+
+    func setConstraints() {
+        collectionView.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide)
+            make.horizontalEdges.equalToSuperview()
+            make.bottom.equalToSuperview()
+        }
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewController/UnvisitedClipListViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewController/UnvisitedClipListViewController.swift
@@ -1,7 +1,10 @@
+import RxCocoa
+import RxSwift
 import UIKit
 
 final class UnvisitedClipListViewController: UIViewController {
     private let clips: [Clip]
+    private let disposeBag = DisposeBag()
 
     private let unvisitedClipListView = UnvisitedClipListView()
 
@@ -16,6 +19,8 @@ final class UnvisitedClipListViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        configure()
+
         let cellDisplays = clips.map {
             ClipCellDisplay(
                 thumbnailImageURL: $0.urlMetadata.thumbnailImageURL,
@@ -29,5 +34,28 @@ final class UnvisitedClipListViewController: UIViewController {
 
     override func loadView() {
         view = unvisitedClipListView
+    }
+}
+
+private extension UnvisitedClipListViewController {
+    func configure() {
+        setBindings()
+    }
+
+    func setBindings() {
+        unvisitedClipListView.action
+            .bind(with: self) { _, action in
+                switch action {
+                case .tap(let index):
+                    print("\(index)번째 클립 탭")
+                case .detail(let index):
+                    print("\(index)번째 클립 상세")
+                case .edit(let index):
+                    print("\(index)번째 클립 수정")
+                case .delete(let index):
+                    print("\(index)번째 클립 삭제")
+                }
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewController/UnvisitedClipListViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewController/UnvisitedClipListViewController.swift
@@ -1,4 +1,33 @@
 import UIKit
 
 final class UnvisitedClipListViewController: UIViewController {
+    private let clips: [Clip]
+
+    private let unvisitedClipListView = UnvisitedClipListView()
+
+    init(clips: [Clip]) {
+        self.clips = clips
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        let cellDisplays = clips.map {
+            ClipCellDisplay(
+                thumbnailImageURL: $0.urlMetadata.thumbnailImageURL,
+                title: $0.urlMetadata.title,
+                memo: $0.memo,
+                isVisited: $0.lastVisitedAt != nil
+            )
+        }
+        unvisitedClipListView.setDisplay(cellDisplays)
+    }
+
+    override func loadView() {
+        view = unvisitedClipListView
+    }
 }

--- a/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewController/UnvisitedClipListViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewController/UnvisitedClipListViewController.swift
@@ -39,7 +39,12 @@ final class UnvisitedClipListViewController: UIViewController {
 
 private extension UnvisitedClipListViewController {
     func configure() {
+        setAttributes()
         setBindings()
+    }
+
+    func setAttributes() {
+        title = "방문하지 않은 클립"
     }
 
     func setBindings() {


### PR DESCRIPTION
## 📌 관련 이슈
close #96 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- 방문하지 않은 클립 리스트 뷰 UI 구현
- viewWillAppear/disappear 될 때 LargeTitle 설정 여부 
- 방문하지 않은 클립 리스트 뷰 이벤트 바인딩

## 📌 구현 내역 스크린샷
| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/7669e873-a903-47ac-bb7a-9581859dc87e" width="250px"> |