### PR TITLE
[Feat] 클립 수정 버튼으로 EditClipView 진입 가능하도록 수정

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
@@ -19,8 +19,8 @@ final class EditClipViewModel: ViewModel {
         var urlInputText: String
         var isHiddenURLMetadataStackView = true
         var isHiddenURLValidationStackView = true
-        var memoText: String
-        var memoLimit: String
+        var memoText: String = ""
+        var memoLimit: String = "0/100"
         var isURLValid = false
         var urlValidationImageName: String = ""
         var urlValidationLabelText: String = ""
@@ -36,14 +36,26 @@ final class EditClipViewModel: ViewModel {
 
     init(
         urlText: String = "",
-        memoText: String = "",
         checkURLValidityUseCase: CheckURLValidityUseCase,
         parseURLMetadataUseCase: ParseURLMetadataUseCase
     ) {
         state = BehaviorRelay(value: State(
-            urlInputText: urlText,
-            memoText: memoText,
-            memoLimit: "\(memoText)/100"
+            urlInputText: urlText
+        ))
+        self.checkURLValidityUseCase = checkURLValidityUseCase
+        self.parseURLMetadataUseCase = parseURLMetadataUseCase
+        bind()
+    }
+
+    init(
+        clip: Clip,
+        checkURLValidityUseCase: CheckURLValidityUseCase,
+        parseURLMetadataUseCase: ParseURLMetadataUseCase
+    ) {
+        state = BehaviorRelay(value: State(
+            urlInputText: clip.urlMetadata.url.absoluteString,
+            memoText: clip.memo,
+            memoLimit: "\(clip.memo)/100"
         ))
         self.checkURLValidityUseCase = checkURLValidityUseCase
         self.parseURLMetadataUseCase = parseURLMetadataUseCase

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
@@ -55,7 +55,7 @@ final class EditClipViewModel: ViewModel {
         state = BehaviorRelay(value: State(
             urlInputText: clip.urlMetadata.url.absoluteString,
             memoText: clip.memo,
-            memoLimit: "\(clip.memo)/100"
+            memoLimit: "\(clip.memo.count)/100"
         ))
         self.checkURLValidityUseCase = checkURLValidityUseCase
         self.parseURLMetadataUseCase = parseURLMetadataUseCase


### PR DESCRIPTION
## 📌 관련 이슈

close #90
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- 이니셜라이저 추가

## 📌 구현
| 실행 기기 | 스크린샷(또는 GIF) | 케이스 |
| :-------------: | :----------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/9b0507c8-d506-4416-a85a-4c3b290b06c6" width="250px"> | 클립 수정 버튼으로 진입 |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/b112aa6a-b270-4cb1-a376-1e3a253b110b" width="250px"> | Share Extension 또는 토스트 뷰로 진입 |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/2cc437bc-25ff-4607-a7b7-a372ca3d22ea" width="250px"> | 클립 생성 버튼으로 진입 |
