### PR TITLE
[Feat] 홈 뷰, 방문하지 않은 클립 뷰 네비게이션 뷰 적용

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Common/Button/BackButton.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/Button/BackButton.swift
@@ -11,6 +11,7 @@ final class BackButton: UIButton {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        configure()
     }
 
     required init?(coder: NSCoder) {

--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -7,7 +7,7 @@ final class HomeView: UIView {
     enum Action {
         case tapAddFolder
         case tapAddClip
-        case tapItem(IndexPath)
+        case tapCell(IndexPath)
         case detail(IndexPath)
         case edit(IndexPath)
         case delete(IndexPath)
@@ -342,7 +342,7 @@ private extension HomeView {
 
     func setBindings() {
         collectionView.rx.itemSelected
-            .map { Action.tapItem($0) }
+            .map { Action.tapCell($0) }
             .bind(to: action)
             .disposed(by: disposeBag)
     }

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -53,7 +53,7 @@ private extension HomeViewController {
                     owner.homeviewModel.action.accept(.tapAddFolder)
                 case .tapAddClip:
                     owner.homeviewModel.action.accept(.tapAddClip)
-                case .tapItem(let indexPath):
+                case .tapCell(let indexPath):
                     owner.homeviewModel.action.accept(.tapCell(indexPath))
                 case .detail(let indexPath):
                     owner.homeviewModel.action.accept(.tapDetail(indexPath))

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -31,59 +31,29 @@ final class HomeViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         homeviewModel.action.accept(.viewWillAppear)
-        navigationController?.navigationBar.prefersLargeTitles = true
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        navigationController?.navigationBar.prefersLargeTitles = false
-    }
-
-    private func makeAddButtonMenu() -> UIMenu {
-        let addFolderAction = UIAction(
-            title: "폴더 추가",
-            image: UIImage(systemName: "folder")
-        ) { [weak self] _ in
-            self?.homeviewModel.action.accept(.tapAddFolder)
-        }
-
-        let addClipAction = UIAction(
-            title: "클립 추가",
-            image: UIImage(systemName: "paperclip"),
-        ) { [weak self] _ in
-            self?.homeviewModel.action.accept(.tapAddClip)
-        }
-
-        return UIMenu(title: "", children: [addFolderAction, addClipAction])
     }
 }
 
 private extension HomeViewController {
     func configure() {
         setAttributes()
-        setNavigationBarItems()
         setBindings()
     }
 
     func setAttributes() {
         title = "Clipster"
-    }
-
-    func setNavigationBarItems() {
-        let addButton = UIBarButtonItem(
-            systemItem: .add,
-            menu: makeAddButtonMenu()
-        )
-
-        navigationController?.navigationBar.tintColor = .label
-        navigationItem.rightBarButtonItem = addButton
+        navigationController?.isNavigationBarHidden = true
     }
 
     func setBindings() {
         homeView.action
             .bind(with: self) { owner, action in
                 switch action {
-                case .tap(let indexPath):
+                case .tapAddFolder:
+                    owner.homeviewModel.action.accept(.tapAddFolder)
+                case .tapAddClip:
+                    owner.homeviewModel.action.accept(.tapAddClip)
+                case .tapItem(let indexPath):
                     owner.homeviewModel.action.accept(.tapCell(indexPath))
                 case .detail(let indexPath):
                     owner.homeviewModel.action.accept(.tapDetail(indexPath))

--- a/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/SubView/View/UnvisitedClipListView.swift
+++ b/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/SubView/View/UnvisitedClipListView.swift
@@ -19,6 +19,15 @@ final class UnvisitedClipListView: UIView {
 
     private var dataSource: UICollectionViewDiffableDataSource<Section, Item>?
 
+    private lazy var navigationView: CommonNavigationView = {
+        let view = CommonNavigationView()
+        view.setTitle("방문하지 않은 클립")
+        view.setLeftItem(backButton)
+        return view
+    }()
+
+    private let backButton = BackButton()
+
     private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(
             frame: .zero,
@@ -80,7 +89,7 @@ private extension UnvisitedClipListView {
 
             let section = NSCollectionLayoutSection(group: group)
             section.interGroupSpacing = 8
-            section.contentInsets = NSDirectionalEdgeInsets(top: 24, leading: 24, bottom: 0, trailing: 24)
+            section.contentInsets = .init(top: 24, leading: 24, bottom: 0, trailing: 24)
             return section
         }
 
@@ -138,12 +147,21 @@ private extension UnvisitedClipListView {
     }
 
     func setHierarchy() {
-        addSubview(collectionView)
+        [
+            collectionView,
+            navigationView
+        ].forEach { addSubview($0) }
     }
 
     func setConstraints() {
-        collectionView.snp.makeConstraints { make in
+        navigationView.snp.makeConstraints { make in
             make.top.equalTo(safeAreaLayoutGuide)
+            make.horizontalEdges.equalToSuperview()
+            make.height.equalTo(56)
+        }
+
+        collectionView.snp.makeConstraints { make in
+            make.top.equalTo(navigationView.snp.bottom)
             make.horizontalEdges.equalToSuperview()
             make.bottom.equalToSuperview()
         }

--- a/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/SubView/View/UnvisitedClipListView.swift
+++ b/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/SubView/View/UnvisitedClipListView.swift
@@ -5,7 +5,8 @@ import UIKit
 
 final class UnvisitedClipListView: UIView {
     enum Action {
-        case tap(Int)
+        case tapBack
+        case tapCell(Int)
         case detail(Int)
         case edit(Int)
         case delete(Int)
@@ -169,7 +170,12 @@ private extension UnvisitedClipListView {
 
     func setBindings() {
         collectionView.rx.itemSelected
-            .map { Action.tap($0.row) }
+            .map { Action.tapCell($0.row) }
+            .bind(to: action)
+            .disposed(by: disposeBag)
+
+        backButton.rx.tap
+            .map { Action.tapBack }
             .bind(to: action)
             .disposed(by: disposeBag)
     }

--- a/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewController/UnvisitedClipListViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewController/UnvisitedClipListViewController.swift
@@ -48,7 +48,9 @@ private extension UnvisitedClipListViewController {
         unvisitedClipListView.action
             .bind(with: self) { owner, action in
                 switch action {
-                case .tap(let index):
+                case .tapBack:
+                    owner.unvisitedClipListViewModel.action.accept(.tapBack)
+                case .tapCell(let index):
                     owner.unvisitedClipListViewModel.action.accept(.tapCell(index))
                 case .detail(let index):
                     owner.unvisitedClipListViewModel.action.accept(.tapDetail(index))
@@ -74,6 +76,8 @@ private extension UnvisitedClipListViewController {
             .asSignal()
             .emit(with: self) { owner, route in
                 switch route {
+                case .back:
+                    owner.navigationController?.popViewController(animated: true)
                 case .showWebView(let url):
                     print("웹 뷰")
                     print("\(url)\n")

--- a/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewModel/UnvisitedClipListViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewModel/UnvisitedClipListViewModel.swift
@@ -5,6 +5,7 @@ import RxSwift
 final class UnvisitedClipListViewModel {
     enum Action {
         case viewWillAppear
+        case tapBack
         case tapCell(Int)
         case tapDetail(Int)
         case tapEdit(Int)
@@ -16,6 +17,7 @@ final class UnvisitedClipListViewModel {
     }
 
     enum Route {
+        case back
         case showWebView(URL)
         case showDetailClip(Clip)
         case showEditClip(Clip)
@@ -51,6 +53,8 @@ final class UnvisitedClipListViewModel {
                 switch action {
                 case .viewWillAppear:
                     Task { await owner.handleViewWillAppear() }
+                case .tapBack:
+                    owner.route.accept(.back)
                 case .tapCell(let index),
                      .tapDetail(let index),
                      .tapEdit(let index):


### PR DESCRIPTION
## 📌 관련 이슈
close #136 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- 홈 뷰 네비게이션 뷰 적용
- 방문하지 않은 클립 뷰 네비게이션 뷰 적용
- 홈 뷰에서 네비게이션 바 Hidden
- BackButton Configure 호출 추가

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/53742b7e-e96b-4fe8-9010-01e628ab4843" width="250px"> |