### PR TITLE
[Refactor] 방문하지 않은 클립 뷰 테이블뷰로 변경

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/SubView/View/UnvisitedClipListView.swift
+++ b/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/SubView/View/UnvisitedClipListView.swift
@@ -33,7 +33,6 @@ final class UnvisitedClipListView: UIView {
         let tableView = UITableView()
         tableView.backgroundColor = #colorLiteral(red: 0.9813517928, green: 0.9819430709, blue: 1, alpha: 1)
         tableView.separatorStyle = .none
-        tableView.allowsSelection = false
         tableView.rowHeight = 72
         tableView.register(ClipCell.self, forCellReuseIdentifier: ClipCell.identifier)
         tableView.delegate = self
@@ -57,6 +56,7 @@ final class UnvisitedClipListView: UIView {
                 for: indexPath
             ) as? ClipCell
             else { return UITableViewCell() }
+            cell.selectionStyle = .none
             cell.setDisplay(item)
             return cell
         }
@@ -67,34 +67,6 @@ final class UnvisitedClipListView: UIView {
         snapshot.appendSections([0])
         snapshot.appendItems(display, toSection: 0)
         dataSource?.apply(snapshot)
-    }
-}
-
-private extension UnvisitedClipListView {
-    func createCollectionViewLayout() -> UICollectionViewLayout {
-        let layout = UICollectionViewCompositionalLayout { _, _ in
-            let itemSize = NSCollectionLayoutSize(
-                widthDimension: .fractionalWidth(1.0),
-                heightDimension: .fractionalHeight(1.0)
-            )
-            let item = NSCollectionLayoutItem(layoutSize: itemSize)
-
-            let groupSize = NSCollectionLayoutSize(
-                widthDimension: .fractionalWidth(1.0),
-                heightDimension: .absolute(72)
-            )
-            let group = NSCollectionLayoutGroup.vertical(
-                layoutSize: groupSize,
-                subitems: [item]
-            )
-
-            let section = NSCollectionLayoutSection(group: group)
-            section.interGroupSpacing = 8
-            section.contentInsets = .init(top: 24, leading: 24, bottom: 0, trailing: 24)
-            return section
-        }
-
-        return layout
     }
 }
 
@@ -135,6 +107,27 @@ extension UnvisitedClipListView: UITableViewDelegate {
     }
 }
 
+extension UnvisitedClipListView {
+    func tableView(
+        _ tableView: UITableView,
+        trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
+    ) -> UISwipeActionsConfiguration? {
+        let delete = UIContextualAction(
+            style: .destructive,
+            title: nil
+        ) { [weak self] _, _, completion in
+            guard let self = self else { return }
+            action.accept(.delete(indexPath.row))
+            completion(true)
+        }
+
+        delete.image = UIImage(systemName: "trash")
+        delete.backgroundColor = .systemRed
+
+        return UISwipeActionsConfiguration(actions: [delete])
+    }
+}
+
 private extension UnvisitedClipListView {
     func configure() {
         setAttributes()
@@ -144,7 +137,7 @@ private extension UnvisitedClipListView {
     }
 
     func setAttributes() {
-        backgroundColor = .systemBackground
+        backgroundColor = #colorLiteral(red: 0.9813517928, green: 0.9819430709, blue: 1, alpha: 1)
     }
 
     func setHierarchy() {


### PR DESCRIPTION
## 📌 관련 이슈
close #158 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- 방문하지 않은 클립 뷰 테이블뷰로 변경

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/418dd496-57a5-423e-b72a-7e159d6e60ed" width="250px"> |

## 📌 참고 사항
세부적인 UI는 피그마 동기화 하면서 한번에 하겠습니다.