### PR TITLE
EditClipView 저장/수정 버튼 로직 구현

### DIFF
--- a/Clipster/Clipster/App/DIContainer/DIContainer.swift
+++ b/Clipster/Clipster/App/DIContainer/DIContainer.swift
@@ -38,6 +38,14 @@ final class DIContainer {
         DefaultURLValidationRepository()
     }
 
+    func makeCreateClipUseCase() -> CreateClipUseCase {
+        DefaultCreateClipUseCase(clipRepository: makeClipRepository())
+    }
+
+    func makeUpdateClipUseCase() -> UpdateClipUseCase {
+        DefaultUpdateClipUseCase(clipRepository: makeClipRepository())
+    }
+
     func makeDeleteClipUseCase() -> DeleteClipUseCase {
         DefaultDeleteClipUseCase(clipRepository: makeClipRepository())
     }
@@ -91,7 +99,9 @@ final class DIContainer {
         EditClipViewModel(
             checkURLValidityUseCase: makeCheckURLValidityUseCase(),
             parseURLMetadataUseCase: makeParseURLMetadataUseCase(),
-            fetchFolderUseCase: makeFetchFolderUseCase()
+            fetchFolderUseCase: makeFetchFolderUseCase(),
+            createClipUseCase: makeCreateClipUseCase(),
+            updateClipUseCase: makeUpdateClipUseCase()
         )
     }
 
@@ -100,7 +110,9 @@ final class DIContainer {
             urlText: urlString,
             checkURLValidityUseCase: makeCheckURLValidityUseCase(),
             parseURLMetadataUseCase: makeParseURLMetadataUseCase(),
-            fetchFolderUseCase: makeFetchFolderUseCase()
+            fetchFolderUseCase: makeFetchFolderUseCase(),
+            createClipUseCase: makeCreateClipUseCase(),
+            updateClipUseCase: makeUpdateClipUseCase()
         )
     }
 
@@ -109,7 +121,9 @@ final class DIContainer {
             clip: clip,
             checkURLValidityUseCase: makeCheckURLValidityUseCase(),
             parseURLMetadataUseCase: makeParseURLMetadataUseCase(),
-            fetchFolderUseCase: makeFetchFolderUseCase()
+            fetchFolderUseCase: makeFetchFolderUseCase(),
+            createClipUseCase: makeCreateClipUseCase(),
+            updateClipUseCase: makeUpdateClipUseCase()
         )
     }
 

--- a/Clipster/Clipster/Domain/Protocol/UseCase/Clip/CreateClipUseCase.swift
+++ b/Clipster/Clipster/Domain/Protocol/UseCase/Clip/CreateClipUseCase.swift
@@ -1,0 +1,3 @@
+protocol CreateClipUseCase {
+    func execute(_ clip: Clip) async -> Result<Void, Error>
+}

--- a/Clipster/Clipster/Domain/Protocol/UseCase/Clip/UpdateClipUseCase.swift
+++ b/Clipster/Clipster/Domain/Protocol/UseCase/Clip/UpdateClipUseCase.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+protocol UpdateClipUseCase {
+    func execute(clip: Clip) async -> Result<Void, Error>
+}

--- a/Clipster/Clipster/Domain/UseCase/Clip/DefaultCreateClipUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/Clip/DefaultCreateClipUseCase.swift
@@ -1,0 +1,20 @@
+//
+//  DefaultCreateClipUseCase.swift
+//  Clipster
+//
+//  Created by 유현진 on 6/11/25.
+//
+
+import Foundation
+
+final class DefaultCreateClipUseCase: CreateClipUseCase {
+    let clipRepository: ClipRepository
+
+    init(clipRepository: ClipRepository) {
+        self.clipRepository = clipRepository
+    }
+
+    func execute(_ clip: Clip) async -> Result<Void, Error> {
+        clipRepository.createClip(clip).mapError { $0 as Error }
+    }
+}

--- a/Clipster/Clipster/Domain/UseCase/Clip/DefaultCreateClipUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/Clip/DefaultCreateClipUseCase.swift
@@ -1,10 +1,3 @@
-//
-//  DefaultCreateClipUseCase.swift
-//  Clipster
-//
-//  Created by 유현진 on 6/11/25.
-//
-
 import Foundation
 
 final class DefaultCreateClipUseCase: CreateClipUseCase {

--- a/Clipster/Clipster/Domain/UseCase/Clip/DefaultUpdateClipUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/Clip/DefaultUpdateClipUseCase.swift
@@ -1,0 +1,11 @@
+final class DefaultUpdateClipUseCase: UpdateClipUseCase {
+    let clipRepository: ClipRepository
+
+    init(clipRepository: ClipRepository) {
+        self.clipRepository = clipRepository
+    }
+
+    func execute(clip: Clip) async -> Result<Void, Error> {
+        clipRepository.updateClip(clip).mapError { $0 as Error }
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -55,6 +55,14 @@ private extension EditClipViewController {
             .drive(editClipView.memoTextView.rx.text)
             .disposed(by: disposeBag)
 
+        viewModel.state
+            .compactMap(\.clip)
+            .take(1)
+            .subscribe { [weak self] _ in
+                self?.viewModel.action.accept(.fetchFolder)
+            }
+            .disposed(by: disposeBag)
+
         editClipView.urlInputTextField
             .rx
             .text
@@ -177,10 +185,7 @@ private extension EditClipViewController {
             .disposed(by: disposeBag)
 
         viewModel.state
-            .compactMap { state -> Folder? in
-                guard state.clip == nil else { return nil }
-                return state.currentFolder
-            }
+            .compactMap(\.currentFolder)
             .asDriver(onErrorDriveWith: .empty())
             .drive { [weak self] in
                 self?.editClipView.folderRowView.setDisplay(

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -226,5 +226,23 @@ private extension EditClipViewController {
                 present(vc, animated: true)
             }
             .disposed(by: disposeBag)
+
+        viewModel.state
+            .map(\.isSuccessfullyEdited)
+            .filter { $0 }
+            .distinctUntilChanged()
+            .asDriver(onErrorDriveWith: .empty())
+            .drive { [weak self] _ in
+                self?.navigationController?.popViewController(animated: true)
+            }
+            .disposed(by: disposeBag)
+
+        editClipView.saveButton
+            .rx
+            .tap
+            .subscribe { [weak self] _ in
+                self?.viewModel.action.accept(.saveClip)
+            }
+            .disposed(by: disposeBag)
     }
 }

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -148,9 +148,10 @@ private extension EditClipViewController {
         Observable.combineLatest(
             viewModel.state.map(\.memoText),
             viewModel.state.map(\.isURLValid),
+            viewModel.state.map(\.currentFolder)
         )
-        .map { memoText, isURLValid in
-            !memoText.isEmpty && isURLValid
+        .map { memoText, isURLValid, currentFolder in
+            !memoText.isEmpty && isURLValid && currentFolder != nil
         }
         .distinctUntilChanged()
         .asDriver(onErrorDriveWith: .empty())

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
@@ -48,13 +48,17 @@ final class EditClipViewModel: ViewModel {
     private let checkURLValidityUseCase: CheckURLValidityUseCase
     private let parseURLMetadataUseCase: ParseURLMetadataUseCase
     private let fetchFolderUseCase: FetchFolderUseCase
+    private let createClipUseCase: CreateClipUseCase
+    private let updateClipUseCase: UpdateClipUseCase
 
     init(
         urlText: String = "",
         currentFolder: Folder? = nil,
         checkURLValidityUseCase: CheckURLValidityUseCase,
         parseURLMetadataUseCase: ParseURLMetadataUseCase,
-        fetchFolderUseCase: FetchFolderUseCase
+        fetchFolderUseCase: FetchFolderUseCase,
+        createClipUseCase: CreateClipUseCase,
+        updateClipUseCase: UpdateClipUseCase
     ) {
         state = BehaviorRelay(value: State(
             type: urlText.isEmpty ? .create : .shareExtension,
@@ -64,6 +68,8 @@ final class EditClipViewModel: ViewModel {
         self.checkURLValidityUseCase = checkURLValidityUseCase
         self.parseURLMetadataUseCase = parseURLMetadataUseCase
         self.fetchFolderUseCase = fetchFolderUseCase
+        self.createClipUseCase = createClipUseCase
+        self.updateClipUseCase = updateClipUseCase
         bind()
     }
 
@@ -71,7 +77,9 @@ final class EditClipViewModel: ViewModel {
         clip: Clip,
         checkURLValidityUseCase: CheckURLValidityUseCase,
         parseURLMetadataUseCase: ParseURLMetadataUseCase,
-        fetchFolderUseCase: FetchFolderUseCase
+        fetchFolderUseCase: FetchFolderUseCase,
+        createClipUseCase: CreateClipUseCase,
+        updateClipUseCase: UpdateClipUseCase
     ) {
         state = BehaviorRelay(value: State(
             type: .edit,
@@ -83,6 +91,8 @@ final class EditClipViewModel: ViewModel {
         self.checkURLValidityUseCase = checkURLValidityUseCase
         self.parseURLMetadataUseCase = parseURLMetadataUseCase
         self.fetchFolderUseCase = fetchFolderUseCase
+        self.createClipUseCase = createClipUseCase
+        self.updateClipUseCase = updateClipUseCase
         bind()
     }
 

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
@@ -15,6 +15,7 @@ final class EditClipViewModel: ViewModel {
         case folderViewTapped
         case editFolder(Folder?)
         case saveClip
+        case fetchFolder
     }
 
     enum Mutation {
@@ -124,11 +125,10 @@ final class EditClipViewModel: ViewModel {
         case .saveClip:
             switch state.value.type {
             case .edit:
-                print("3")
                 guard let clip = state.value.clip else { return .empty() }
                 guard let currentFolder = state.value.currentFolder else { return .empty() }
                 guard let urlMetadata = state.value.urlMetadata else { return .empty() }
-                print("4")
+
                 let newClip = Clip(
                     id: clip.id,
                     folderID: currentFolder.id,
@@ -154,10 +154,9 @@ final class EditClipViewModel: ViewModel {
                 .map { .updateSuccessfullyEdited(true) }
                 .catchAndReturn(.updateSuccessfullyEdited(false))
             case .create, .shareExtension:
-                print("1")
                 guard let currentFolder = state.value.currentFolder else { return .empty() }
                 guard let urlMetadata = state.value.urlMetadata else { return .empty() }
-                print("2")
+
                 let newClip = Clip(
                     id: UUID(),
                     folderID: currentFolder.id,
@@ -181,6 +180,13 @@ final class EditClipViewModel: ViewModel {
                 .map { .updateSuccessfullyEdited(true) }
                 .catchAndReturn(.updateSuccessfullyEdited(false))
             }
+        case .fetchFolder:
+            guard let clip = state.value.clip else { return .empty() }
+            return .fromAsync {
+                try await self.fetchFolderUseCase.execute(id: clip.folderID).get()
+            }
+            .map { .updateCurrentFolder($0) }
+            .catchAndReturn(.updateCurrentFolder(nil))
         }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈

close #89 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- Clip Create/Update UseCase & Repository 구현
- VIewModel 및 DIContainer 수정
- 클립 저장/수정 구현

## 📌 구현 내역 스크린샷
| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/3733efeb-ea7a-4434-a040-6b09c337315b" width="250px"> |

## 📌 참고 사항
현재 인지하고 있는 예외처리 사항에 대해 다음 PR에 구현 예정
- 폴더 없을 때 EmptyView
- 클립 편집 버튼으로 EditClipVIew 진입 시 저장된 내용과 현재 기록된 내용 비교하여 저장 버튼 활성화 여부 결정
- Share Extension으로 EditClipView 진입 시 홈(최상위)에 생성된 폴더 중 아무거나 가져오기
