### PR TITLE
클립 추가 화면 제일 최근에 수정된 폴더 전달

### DIFF
--- a/Clipster/Clipster/App/DIContainer/DIContainer.swift
+++ b/Clipster/Clipster/App/DIContainer/DIContainer.swift
@@ -116,6 +116,17 @@ final class DIContainer {
         )
     }
 
+    func makeEditClipViewModel(folder: Folder?) -> EditClipViewModel {
+        EditClipViewModel(
+            currentFolder: folder,
+            checkURLValidityUseCase: makeCheckURLValidityUseCase(),
+            parseURLMetadataUseCase: makeParseURLMetadataUseCase(),
+            fetchFolderUseCase: makeFetchFolderUseCase(),
+            createClipUseCase: makeCreateClipUseCase(),
+            updateClipUseCase: makeUpdateClipUseCase()
+        )
+    }
+
     func makeEditClipViewModel(clip: Clip) -> EditClipViewModel {
         EditClipViewModel(
             clip: clip,

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewController/HomeViewController.swift
@@ -83,8 +83,8 @@ private extension HomeViewController {
             .asSignal()
             .emit(with: self) { owner, route in
                 switch route {
-                case .showAddClip:
-                    let vm = owner.diContainer.makeEditClipViewModel()
+                case .showAddClip(let folder):
+                    let vm = owner.diContainer.makeEditClipViewModel(folder: folder)
                     let vc = EditClipViewController(
                         viewModel: vm,
                         diContainer: owner.diContainer

--- a/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/ViewModel/HomeViewModel.swift
@@ -20,7 +20,7 @@ final class HomeViewModel {
     }
 
     enum Route {
-        case showAddClip
+        case showAddClip(Folder?)
         case showAddFolder
         case showWebView(URL)
         case showFolder(Folder)
@@ -64,7 +64,8 @@ final class HomeViewModel {
                 case .viewWillAppear:
                     Task { await owner.makeHomeDisplay() }
                 case .tapAddClip:
-                    owner.route.accept(.showAddClip)
+                    let latestFolder = owner.folders.max { $0.updatedAt < $1.updatedAt }
+                    owner.route.accept(.showAddClip(latestFolder))
                 case .tapAddFolder:
                     owner.route.accept(.showAddFolder)
                 case .tapClip(let index):


### PR DESCRIPTION
## 📌 관련 이슈
close #190 
  
## 📌 PR 유형
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- 클립추가 화면 이동 시 최근에 수정된 폴더 전달

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/11437b01-a215-4275-9ea5-3457f6bbbe06" width="250px"> |

## 📌 참고 사항
- 폴더가 없을경우에는 폴더이름이 비어있는걸로 확인됐습니다