### PR TITLE
EditClipVIew 최상위 폴더 가져오기 구현

### DIFF
--- a/Clipster/Clipster/App/DIContainer/DIContainer.swift
+++ b/Clipster/Clipster/App/DIContainer/DIContainer.swift
@@ -100,6 +100,7 @@ final class DIContainer {
             checkURLValidityUseCase: makeCheckURLValidityUseCase(),
             parseURLMetadataUseCase: makeParseURLMetadataUseCase(),
             fetchFolderUseCase: makeFetchFolderUseCase(),
+            fetchTopLevelFoldersUseCase: makeFetchTopLevelFoldersUseCase(),
             createClipUseCase: makeCreateClipUseCase(),
             updateClipUseCase: makeUpdateClipUseCase()
         )
@@ -111,6 +112,7 @@ final class DIContainer {
             checkURLValidityUseCase: makeCheckURLValidityUseCase(),
             parseURLMetadataUseCase: makeParseURLMetadataUseCase(),
             fetchFolderUseCase: makeFetchFolderUseCase(),
+            fetchTopLevelFoldersUseCase: makeFetchTopLevelFoldersUseCase(),
             createClipUseCase: makeCreateClipUseCase(),
             updateClipUseCase: makeUpdateClipUseCase()
         )
@@ -133,6 +135,7 @@ final class DIContainer {
             checkURLValidityUseCase: makeCheckURLValidityUseCase(),
             parseURLMetadataUseCase: makeParseURLMetadataUseCase(),
             fetchFolderUseCase: makeFetchFolderUseCase(),
+            fetchTopLevelFoldersUseCase: makeFetchTopLevelFoldersUseCase(),
             createClipUseCase: makeCreateClipUseCase(),
             updateClipUseCase: makeUpdateClipUseCase()
         )

--- a/Clipster/Clipster/App/DIContainer/DIContainer.swift
+++ b/Clipster/Clipster/App/DIContainer/DIContainer.swift
@@ -124,6 +124,7 @@ final class DIContainer {
             checkURLValidityUseCase: makeCheckURLValidityUseCase(),
             parseURLMetadataUseCase: makeParseURLMetadataUseCase(),
             fetchFolderUseCase: makeFetchFolderUseCase(),
+            fetchTopLevelFoldersUseCase: makeFetchTopLevelFoldersUseCase(),
             createClipUseCase: makeCreateClipUseCase(),
             updateClipUseCase: makeUpdateClipUseCase()
         )

--- a/Clipster/Clipster/Data/Model/Clipster.xcdatamodeld/Clipster.xcdatamodel/contents
+++ b/Clipster/Clipster/Data/Model/Clipster.xcdatamodeld/Clipster.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24F74" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24E263" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="Clip" representedClassName="Clip" syncable="YES">
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="deletedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -25,7 +25,7 @@
         <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="deletedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="depth" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="thumbnailImageURLString" attributeType="String" defaultValueString=""/>
+        <attribute name="thumbnailImageURLString" optional="YES" attributeType="String" defaultValueString=""/>
         <attribute name="title" attributeType="String" defaultValueString=""/>
         <attribute name="updatedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="urlString" attributeType="String" defaultValueString=""/>

--- a/Clipster/Clipster/Data/Model/URLMetadataEntity.swift
+++ b/Clipster/Clipster/Data/Model/URLMetadataEntity.swift
@@ -4,7 +4,7 @@ import CoreData
 public class URLMetadataEntity: NSManagedObject {
     @NSManaged public var urlString: String
     @NSManaged public var title: String
-    @NSManaged public var thumbnailImageURLString: String
+    @NSManaged public var thumbnailImageURLString: String?
     @NSManaged public var createdAt: Date
     @NSManaged public var updatedAt: Date
     @NSManaged public var deletedAt: Date?

--- a/Clipster/Clipster/Data/Persistence/DefaultClipStorage.swift
+++ b/Clipster/Clipster/Data/Persistence/DefaultClipStorage.swift
@@ -93,7 +93,7 @@ final class DefaultClipStorage: ClipStorage {
 
             entity.urlMetadata?.urlString = clip.urlMetadata.url.absoluteString
             entity.urlMetadata?.title = clip.urlMetadata.title
-            entity.urlMetadata?.thumbnailImageURLString = clip.urlMetadata.thumbnailImageURL.absoluteString
+            entity.urlMetadata?.thumbnailImageURLString = clip.urlMetadata.thumbnailImageURL?.absoluteString
             entity.urlMetadata?.updatedAt = clip.urlMetadata.updatedAt
 
             try context.save()
@@ -140,7 +140,7 @@ final class DefaultClipStorage: ClipStorage {
         let entity = URLMetadataEntity(context: context)
         entity.urlString = urlMetadata.url.absoluteString
         entity.title = urlMetadata.title
-        entity.thumbnailImageURLString = urlMetadata.thumbnailImageURL.absoluteString
+        entity.thumbnailImageURLString = urlMetadata.thumbnailImageURL?.absoluteString
         entity.createdAt = urlMetadata.createdAt
         entity.updatedAt = urlMetadata.updatedAt
 

--- a/Clipster/Clipster/Data/Util/Mapper/DomainMapper.swift
+++ b/Clipster/Clipster/Data/Util/Mapper/DomainMapper.swift
@@ -41,7 +41,7 @@ struct DomainMapper {
 
     private func urlMetadata(from entity: URLMetadataEntity) -> URLMetadata? {
         guard let url = URL(string: entity.urlString),
-              let thumbnailImageURL = URL(string: entity.thumbnailImageURLString) else {
+              let thumbnailImageURL = URL(string: entity.thumbnailImageURLString ?? "") else {
             return nil
         }
 

--- a/Clipster/Clipster/Domain/Model/URLMetadata.swift
+++ b/Clipster/Clipster/Domain/Model/URLMetadata.swift
@@ -3,7 +3,7 @@ import Foundation
 struct URLMetadata {
     let url: URL
     let title: String
-    let thumbnailImageURL: URL
+    let thumbnailImageURL: URL?
     let createdAt: Date
     let updatedAt: Date
     let deletedAt: Date?

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -154,12 +154,17 @@ private extension EditClipViewController {
             .disposed(by: disposeBag)
 
         Observable.combineLatest(
+            viewModel.state.map(\.clip),
             viewModel.state.map(\.memoText),
             viewModel.state.map(\.isURLValid),
             viewModel.state.map(\.currentFolder)
         )
-        .map { memoText, isURLValid, currentFolder in
-            !memoText.isEmpty && isURLValid && currentFolder != nil
+        .map { clip, memoText, isURLValid, currentFolder in
+            if let clip = clip {
+                return clip.memo != memoText || !isURLValid || currentFolder?.id != clip.folderID
+            } else {
+                return !memoText.isEmpty && isURLValid && currentFolder != nil
+            }
         }
         .distinctUntilChanged()
         .asDriver(onErrorDriveWith: .empty())

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -63,6 +63,14 @@ private extension EditClipViewController {
             }
             .disposed(by: disposeBag)
 
+        viewModel.state
+            .map { $0.type == .shareExtension }
+            .take(1)
+            .subscribe { [weak self] _ in
+                self?.viewModel.action.accept(.fetchTopLevelFolder)
+            }
+            .disposed(by: disposeBag)
+
         editClipView.urlInputTextField
             .rx
             .text

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
@@ -135,7 +135,7 @@ final class EditClipViewModel: ViewModel {
                     urlMetadata: URLMetadata(
                         url: urlMetadata.url,
                         title: urlMetadata.title,
-                        thumbnailImageURL: urlMetadata.thumbnailImageURL!,
+                        thumbnailImageURL: urlMetadata.thumbnailImageURL,
                         createdAt: clip.createdAt,
                         updatedAt: clip.urlMetadata.url != urlMetadata.url ? Date() : clip.updatedAt,
                         deletedAt: clip.deletedAt
@@ -163,7 +163,7 @@ final class EditClipViewModel: ViewModel {
                     urlMetadata: URLMetadata(
                         url: urlMetadata.url,
                         title: urlMetadata.title,
-                        thumbnailImageURL: urlMetadata.thumbnailImageURL!,
+                        thumbnailImageURL: urlMetadata.thumbnailImageURL,
                         createdAt: Date(),
                         updatedAt: Date(),
                         deletedAt: nil

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
@@ -16,6 +16,7 @@ final class EditClipViewModel: ViewModel {
         case editFolder(Folder?)
         case saveClip
         case fetchFolder
+        case fetchTopLevelFolder
     }
 
     enum Mutation {
@@ -190,6 +191,13 @@ final class EditClipViewModel: ViewModel {
             return .fromAsync {
                 try await self.fetchFolderUseCase.execute(id: clip.folderID).get()
             }
+            .map { .updateCurrentFolder($0) }
+            .catchAndReturn(.updateCurrentFolder(nil))
+        case .fetchTopLevelFolder:
+            return .fromAsync {
+                try await self.fetchTopLevelFoldersUseCase.execute().get()
+            }
+            .map { $0.max(by: { $0.updatedAt < $1.updatedAt }) }
             .map { .updateCurrentFolder($0) }
             .catchAndReturn(.updateCurrentFolder(nil))
         }

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
@@ -109,6 +109,7 @@ final class EditClipViewModel: ViewModel {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .editURLInputTextField(let urlText):
+            print("\(Self.self) \(action)")
             return .merge(
                 .just(.updateURLInputText(urlText)),
                 .fromAsync {
@@ -123,14 +124,19 @@ final class EditClipViewModel: ViewModel {
                 .catchAndReturn(.updateURLMetadata(nil))
             )
         case .editMomo(let memoText):
+            print("\(Self.self) \(action)")
             return .just(.updateMemo(memoText))
         case .folderViewTapped:
+            print("\(Self.self) \(action)")
             return .just(.updateFolderViewTapped(true))
         case .editFolder(let newFolder):
+            print("\(Self.self) \(action)")
             return .just(.updateCurrentFolder(newFolder))
         case .saveClip:
+            print("\(Self.self) \(action)")
             switch state.value.type {
             case .edit:
+                print("\(Self.self) edit clip")
                 guard let clip = state.value.clip else { return .empty() }
                 guard let currentFolder = state.value.currentFolder else { return .empty() }
                 guard let urlMetadata = state.value.urlMetadata else { return .empty() }
@@ -160,6 +166,7 @@ final class EditClipViewModel: ViewModel {
                 .map { .updateSuccessfullyEdited(true) }
                 .catchAndReturn(.updateSuccessfullyEdited(false))
             case .create, .shareExtension:
+                print("\(Self.self) save clip")
                 guard let currentFolder = state.value.currentFolder else { return .empty() }
                 guard let urlMetadata = state.value.urlMetadata else { return .empty() }
 
@@ -187,6 +194,7 @@ final class EditClipViewModel: ViewModel {
                 .catchAndReturn(.updateSuccessfullyEdited(false))
             }
         case .fetchFolder:
+            print("\(Self.self) \(action)")
             guard let clip = state.value.clip else { return .empty() }
             return .fromAsync {
                 try await self.fetchFolderUseCase.execute(id: clip.folderID).get()
@@ -194,6 +202,7 @@ final class EditClipViewModel: ViewModel {
             .map { .updateCurrentFolder($0) }
             .catchAndReturn(.updateCurrentFolder(nil))
         case .fetchTopLevelFolder:
+            print("\(Self.self) \(action)")
             return .fromAsync {
                 try await self.fetchTopLevelFoldersUseCase.execute().get()
             }

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
@@ -52,6 +52,7 @@ final class EditClipViewModel: ViewModel {
     private let checkURLValidityUseCase: CheckURLValidityUseCase
     private let parseURLMetadataUseCase: ParseURLMetadataUseCase
     private let fetchFolderUseCase: FetchFolderUseCase
+    private let fetchTopLevelFoldersUseCase: FetchTopLevelFoldersUseCase
     private let createClipUseCase: CreateClipUseCase
     private let updateClipUseCase: UpdateClipUseCase
 
@@ -61,6 +62,7 @@ final class EditClipViewModel: ViewModel {
         checkURLValidityUseCase: CheckURLValidityUseCase,
         parseURLMetadataUseCase: ParseURLMetadataUseCase,
         fetchFolderUseCase: FetchFolderUseCase,
+        fetchTopLevelFoldersUseCase: FetchTopLevelFoldersUseCase,
         createClipUseCase: CreateClipUseCase,
         updateClipUseCase: UpdateClipUseCase
     ) {
@@ -72,6 +74,7 @@ final class EditClipViewModel: ViewModel {
         self.checkURLValidityUseCase = checkURLValidityUseCase
         self.parseURLMetadataUseCase = parseURLMetadataUseCase
         self.fetchFolderUseCase = fetchFolderUseCase
+        self.fetchTopLevelFoldersUseCase = fetchTopLevelFoldersUseCase
         self.createClipUseCase = createClipUseCase
         self.updateClipUseCase = updateClipUseCase
         bind()
@@ -82,6 +85,7 @@ final class EditClipViewModel: ViewModel {
         checkURLValidityUseCase: CheckURLValidityUseCase,
         parseURLMetadataUseCase: ParseURLMetadataUseCase,
         fetchFolderUseCase: FetchFolderUseCase,
+        fetchTopLevelFoldersUseCase: FetchTopLevelFoldersUseCase,
         createClipUseCase: CreateClipUseCase,
         updateClipUseCase: UpdateClipUseCase
     ) {
@@ -95,6 +99,7 @@ final class EditClipViewModel: ViewModel {
         self.checkURLValidityUseCase = checkURLValidityUseCase
         self.parseURLMetadataUseCase = parseURLMetadataUseCase
         self.fetchFolderUseCase = fetchFolderUseCase
+        self.fetchTopLevelFoldersUseCase = fetchTopLevelFoldersUseCase
         self.createClipUseCase = createClipUseCase
         self.updateClipUseCase = updateClipUseCase
         bind()

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
@@ -197,7 +197,7 @@ final class EditClipViewModel: ViewModel {
             return .fromAsync {
                 try await self.fetchTopLevelFoldersUseCase.execute().get()
             }
-            .map { $0.max(by: { $0.updatedAt < $1.updatedAt }) }
+            .map { $0.max { $0.updatedAt < $1.updatedAt } }
             .map { .updateCurrentFolder($0) }
             .catchAndReturn(.updateCurrentFolder(nil))
         }


### PR DESCRIPTION
## 📌 관련 이슈

close #{ISSUE_NUMBER}
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- CoreData Entity 옵셔널 타입 추가
- EditViewModel useCase 추가 + DIContainer 수정
- 로깅 추가

## 📌 PR Point
- Share Extension으로 앱 진입 시 최상위 폴더 중 가장 최근 수정된 폴더를 가져옵니다.
- 클립 수정하기로 EditClipView 진입 시 저장된 Clip 정보와 다를 경우에만 저장 버튼이 활성화 됩니다.
