### PR TITLE
홈 선택시 폴더 선택 화면 보이게 수정

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
@@ -49,18 +49,8 @@ private extension EditFolderViewController {
             .disposed(by: disposeBag)
 
         state
-            .map { $0.parentFolder == nil }
-            .distinctUntilChanged()
-            .observe(on: MainScheduler.instance)
-            .subscribe { [weak self] isHidden in
-                self?.editFolderView.folderView.isHidden = isHidden
-                self?.editFolderView.folderLabel.isHidden = isHidden
-            }
-            .disposed(by: disposeBag)
-
-        state
-            .compactMap { $0.parentFolderDisplay }
-            .distinctUntilChanged { $0.id == $1.id }
+            .map { $0.parentFolderDisplay }
+            .distinctUntilChanged { $0?.id == $1?.id }
             .observe(on: MainScheduler.instance)
             .subscribe { [weak self] parentFolderDisplay in
                 self?.editFolderView.folderRowView.setDisplay(parentFolderDisplay)


### PR DESCRIPTION
## 📌 관련 이슈

close #200 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

홈 선택 시 이후에도 지속적으로 폴더 변경이 가능하게 하기 위함

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/d0c3eedd-c68b-4b8c-8966-f3219600a91e" width="250px"> |
