### PR TITLE
방문하지 않은 클립 뷰 리팩토링 및 Alert 추가

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/ClipDetail/ViewController/ClipDetailViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/ClipDetail/ViewController/ClipDetailViewController.swift
@@ -79,18 +79,20 @@ private extension ClipDetailViewController {
             .map { $0.showDeleteConfirmation }
             .distinctUntilChanged()
             .filter { $0 }
+            .withLatestFrom(state.map { $0.clipDisplay.urlMetadata.title })
             .observe(on: MainScheduler.instance)
-            .subscribe { [weak self] _ in
+            .subscribe { [weak self] title in
                 guard let self else { return }
 
-                let alert = UIAlertController(title: "삭제 확인", message: "이 클립을 정말 삭제하시겠습니까?", preferredStyle: .alert)
-                alert.addAction(UIAlertAction(title: "취소", style: .cancel) { _ in
-                    self.viewModel.action.accept(.deleteCanceled)
-                })
-                alert.addAction(UIAlertAction(title: "삭제", style: .destructive) { _ in
-                    self.viewModel.action.accept(.deleteConfirmed)
-                })
-                self.present(alert, animated: true)
+                self.presentDeleteAlert(
+                    title: title,
+                    onCancel: {
+                        self.viewModel.action.accept(.deleteCanceled)
+                    },
+                    onConfirm: {
+                        self.viewModel.action.accept(.deleteConfirmed)
+                    }
+                )
             }
             .disposed(by: disposeBag)
 

--- a/Clipster/Clipster/Presentation/Scene/Common/Cell/ClipListCell.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/Cell/ClipListCell.swift
@@ -1,0 +1,124 @@
+import Kingfisher
+import SnapKit
+import UIKit
+
+final class ClipListCell: UICollectionViewListCell {
+    private let thumbnailImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.layer.cornerRadius = 8
+        imageView.clipsToBounds = true
+        return imageView
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .pretendard(size: 16, weight: .semiBold)
+        label.textColor = .black100
+        return label
+    }()
+
+    private let memoLabel: UILabel = {
+        let label = UILabel()
+        label.font = .pretendard(size: 12, weight: .regular)
+        label.textColor = .black500
+        return label
+    }()
+
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [titleLabel, memoLabel])
+        stackView.axis = .vertical
+        stackView.spacing = 8
+        stackView.distribution = .fillProportionally
+        return stackView
+    }()
+
+    private let chevronImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.image = .chevronRight
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+
+    private let visitIndicatorView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .blue400
+        view.layer.cornerRadius = 4
+        view.isHidden = true
+        return view
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configure()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let inset = UIEdgeInsets(top: 4, left: 0, bottom: 4, right: 0)
+        contentView.frame = contentView.frame.inset(by: inset)
+    }
+
+    func setDisplay(_ display: ClipDisplay) {
+        thumbnailImageView.kf.setImage(with: display.urlMetadata.thumbnailImageURL)
+        titleLabel.text = display.urlMetadata.title
+        memoLabel.text = display.memo
+        visitIndicatorView.isHidden = display.isVisited
+    }
+}
+
+private extension ClipListCell {
+    func configure() {
+        setAttributes()
+        setHierarchy()
+        setConstraints()
+    }
+
+    func setAttributes() {
+        var background = UIBackgroundConfiguration.clear()
+        background.backgroundColor = .white900
+        background.cornerRadius = 12
+        background.backgroundInsets = .init(top: 0, leading: 24, bottom: 0, trailing: 0)
+        self.backgroundConfiguration = background
+    }
+
+    func setHierarchy() {
+        [
+            thumbnailImageView,
+            stackView,
+            chevronImageView,
+            visitIndicatorView
+        ].forEach { contentView.addSubview($0) }
+    }
+
+    func setConstraints() {
+        thumbnailImageView.snp.makeConstraints { make in
+            make.leading.equalToSuperview().inset(44)
+            make.width.equalTo(64)
+            make.height.equalTo(48)
+            make.centerY.equalToSuperview()
+        }
+
+        stackView.snp.makeConstraints { make in
+            make.leading.equalTo(thumbnailImageView.snp.trailing).offset(16)
+            make.verticalEdges.equalToSuperview().inset(12.95)
+        }
+
+        chevronImageView.snp.makeConstraints { make in
+            make.leading.equalTo(stackView.snp.trailing).offset(16)
+            make.trailing.equalToSuperview().inset(20)
+            make.size.equalTo(24)
+            make.centerY.equalToSuperview()
+        }
+
+        visitIndicatorView.snp.makeConstraints { make in
+            make.leading.equalTo(thumbnailImageView.snp.leading).inset(6)
+            make.top.equalTo(thumbnailImageView.snp.top).inset(6)
+            make.size.equalTo(8)
+        }
+    }
+}

--- a/Clipster/Clipster/Presentation/Scene/Folder/ViewController/FolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/ViewController/FolderViewController.swift
@@ -144,22 +144,9 @@ private extension FolderViewController {
             .asDriver(onErrorDriveWith: .empty())
             .drive { [weak self] (indexPath, title) in
                 guard let self else { return }
-
-                let alertController = UIAlertController(
-                    title: title,
-                    message: "삭제하겠습니까?",
-                    preferredStyle: .alert,
-                )
-
-                let cancelAction = UIAlertAction(title: "취소", style: .cancel)
-                alertController.addAction(cancelAction)
-
-                let deleteAction = UIAlertAction(title: "삭제", style: .destructive) { _ in
-                    self.viewModel.action.accept(.didTapDeleteButton(indexPath))
+                presentDeleteAlert(title: title) { [weak self] in
+                    self?.viewModel.action.accept(.didTapDeleteButton(indexPath))
                 }
-                alertController.addAction(deleteAction)
-
-                self.present(alertController, animated: true)
             }
             .disposed(by: disposeBag)
     }

--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -77,7 +77,6 @@ final class HomeView: UIView {
         }
 
         dataSource = .init(collectionView: collectionView) { collectionView, indexPath, item in
-            print(item)
             switch item {
             case .clip(let clipItem):
                 return collectionView.dequeueConfiguredReusableCell(

--- a/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/SubView/View/UnvisitedClipListView.swift
+++ b/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/SubView/View/UnvisitedClipListView.swift
@@ -18,7 +18,7 @@ final class UnvisitedClipListView: UIView {
     private let disposeBag = DisposeBag()
     let action = PublishRelay<Action>()
 
-    private var dataSource: UITableViewDiffableDataSource<Section, Item>?
+    private var dataSource: UICollectionViewDiffableDataSource<Section, Item>?
 
     private lazy var navigationView: CommonNavigationView = {
         let view = CommonNavigationView()
@@ -29,14 +29,15 @@ final class UnvisitedClipListView: UIView {
 
     private let backButton = BackButton()
 
-    private lazy var tableView: UITableView = {
-        let tableView = UITableView()
-        tableView.backgroundColor = #colorLiteral(red: 0.9813517928, green: 0.9819430709, blue: 1, alpha: 1)
-        tableView.separatorStyle = .none
-        tableView.rowHeight = 72
-        tableView.register(ClipCell.self, forCellReuseIdentifier: ClipCell.identifier)
-        tableView.delegate = self
-        return tableView
+    private lazy var collectionView: UICollectionView = {
+        let collectionView = UICollectionView(
+            frame: .zero,
+            collectionViewLayout: createCollectionViewLayout()
+        )
+        collectionView.delegate = self
+        collectionView.contentInset.top = 24
+        collectionView.backgroundColor = .white800
+        return collectionView
     }()
 
     override init(frame: CGRect) {
@@ -50,30 +51,62 @@ final class UnvisitedClipListView: UIView {
     }
 
     private func configureDataSource() {
-        dataSource = .init(tableView: tableView) { tableView, indexPath, item in
-            guard let cell = tableView.dequeueReusableCell(
-                withIdentifier: ClipCell.identifier,
-                for: indexPath
-            ) as? ClipCell
-            else { return UITableViewCell() }
-            cell.selectionStyle = .none
+        let clipCellRegistration = UICollectionView.CellRegistration<ClipListCell, ClipDisplay> { cell, _, item in
             cell.setDisplay(item)
-            return cell
+        }
+
+        dataSource = .init(collectionView: collectionView) { collectionView, indexPath, item in
+            collectionView.dequeueConfiguredReusableCell(
+                using: clipCellRegistration,
+                for: indexPath,
+                item: item
+            )
         }
     }
 
     func setDisplay(_ display: [ClipDisplay]) {
         var snapshot = NSDiffableDataSourceSnapshot<Section, Item>()
         snapshot.appendSections([0])
-        snapshot.appendItems(display, toSection: 0)
+        snapshot.appendItems(display)
         dataSource?.apply(snapshot)
     }
 }
 
-extension UnvisitedClipListView: UITableViewDelegate {
-    func tableView(
-        _ tableView: UITableView,
-        contextMenuConfigurationForRowAt indexPath: IndexPath,
+private extension UnvisitedClipListView {
+    func createCollectionViewLayout() -> UICollectionViewLayout {
+        UICollectionViewCompositionalLayout { [weak self] _, env in
+            guard let self else { return nil }
+
+            var config = UICollectionLayoutListConfiguration(appearance: .plain)
+            config.showsSeparators = false
+            config.backgroundColor = .white800
+            config.trailingSwipeActionsConfigurationProvider = { indexPath in
+                let delete = UIContextualAction(
+                    style: .destructive,
+                    title: "삭제"
+                ) { _, _, completion in
+                    self.action.accept(.delete(indexPath.item))
+                    completion(true)
+                }
+
+                delete.image = .trashWhite
+                delete.backgroundColor = .red600
+
+                return UISwipeActionsConfiguration(actions: [delete])
+            }
+            let section = NSCollectionLayoutSection.list(using: config, layoutEnvironment: env)
+            section.contentInsets = .init(top: 0, leading: 0, bottom: 0, trailing: 24)
+            section.interGroupSpacing = 8
+
+            return section
+        }
+    }
+}
+
+extension UnvisitedClipListView: UICollectionViewDelegate {
+    func collectionView(
+        _ collectionView: UICollectionView,
+        contextMenuConfigurationForItemAt indexPath: IndexPath,
         point: CGPoint
     ) -> UIContextMenuConfiguration? {
         UIContextMenuConfiguration(
@@ -108,9 +141,9 @@ extension UnvisitedClipListView: UITableViewDelegate {
 }
 
 extension UnvisitedClipListView {
-    func tableView(
-        _ tableView: UITableView,
-        trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath
+    func collectionView(
+        _ collectionView: UICollectionView,
+        trailingSwipeActionsConfigurationForItemAt indexPath: IndexPath
     ) -> UISwipeActionsConfiguration? {
         let delete = UIContextualAction(
             style: .destructive,
@@ -137,13 +170,13 @@ private extension UnvisitedClipListView {
     }
 
     func setAttributes() {
-        backgroundColor = #colorLiteral(red: 0.9813517928, green: 0.9819430709, blue: 1, alpha: 1)
+        backgroundColor = .white800
     }
 
     func setHierarchy() {
         [
-            tableView,
-            navigationView
+            navigationView,
+            collectionView
         ].forEach { addSubview($0) }
     }
 
@@ -154,7 +187,11 @@ private extension UnvisitedClipListView {
             make.height.equalTo(56)
         }
 
-        tableView.snp.makeConstraints { make in
+        backButton.snp.makeConstraints { make in
+            make.size.equalTo(44)
+        }
+
+        collectionView.snp.makeConstraints { make in
             make.top.equalTo(navigationView.snp.bottom)
             make.horizontalEdges.equalToSuperview()
             make.bottom.equalToSuperview()
@@ -162,13 +199,13 @@ private extension UnvisitedClipListView {
     }
 
     func setBindings() {
-        tableView.rx.itemSelected
-            .map { Action.tapCell($0.row) }
+        backButton.rx.tap
+            .map { Action.tapBack }
             .bind(to: action)
             .disposed(by: disposeBag)
 
-        backButton.rx.tap
-            .map { Action.tapBack }
+        collectionView.rx.itemSelected
+            .map { Action.tapCell($0.item) }
             .bind(to: action)
             .disposed(by: disposeBag)
     }

--- a/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/SubView/View/UnvisitedClipListView.swift
+++ b/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/SubView/View/UnvisitedClipListView.swift
@@ -188,7 +188,7 @@ private extension UnvisitedClipListView {
         }
 
         backButton.snp.makeConstraints { make in
-            make.size.equalTo(44)
+            make.size.equalTo(48)
         }
 
         collectionView.snp.makeConstraints { make in

--- a/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewController/UnvisitedClipListViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewController/UnvisitedClipListViewController.swift
@@ -56,8 +56,10 @@ private extension UnvisitedClipListViewController {
                     owner.unvisitedClipListViewModel.action.accept(.tapDetail(index))
                 case .edit(let index):
                     owner.unvisitedClipListViewModel.action.accept(.tapEdit(index))
-                case .delete(let index):
-                    owner.unvisitedClipListViewModel.action.accept(.tapDelete(index))
+                case .delete(let index, let title):
+                    owner.presentDeleteAlert(title: title) { [weak self] in
+                        self?.unvisitedClipListViewModel.action.accept(.tapDelete(index))
+                    }
                 }
             }
             .disposed(by: disposeBag)

--- a/Clipster/Clipster/Presentation/Util/Extension/ViewController+Extension.swift
+++ b/Clipster/Clipster/Presentation/Util/Extension/ViewController+Extension.swift
@@ -14,6 +14,7 @@ extension UIViewController {
     func presentDeleteAlert(
         title: String,
         message: String = "삭제하겠습니까?",
+        onCancel: @escaping () -> Void = {},
         onConfirm: @escaping () -> Void
     ) {
         let trimmedTitle = title.count > 20

--- a/Clipster/Clipster/Presentation/Util/Extension/ViewController+Extension.swift
+++ b/Clipster/Clipster/Presentation/Util/Extension/ViewController+Extension.swift
@@ -10,4 +10,27 @@ extension UIViewController {
     @objc func dismissKeyboard() {
         view.endEditing(true)
     }
+
+    func presentDeleteAlert(
+        title: String,
+        message: String = "삭제하겠습니까?",
+        onConfirm: @escaping () -> Void
+    ) {
+        let trimmedTitle = title.count > 20
+            ? String(title.prefix(20)) + "...는"
+            : title + "는"
+
+        let alert = UIAlertController(
+            title: trimmedTitle,
+            message: message,
+            preferredStyle: .alert
+        )
+
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+        alert.addAction(UIAlertAction(title: "삭제", style: .destructive) { _ in
+            onConfirm()
+        })
+
+        present(alert, animated: true)
+    }
 }

--- a/Clipster/Clipster/Presentation/Util/Extension/ViewController+Extension.swift
+++ b/Clipster/Clipster/Presentation/Util/Extension/ViewController+Extension.swift
@@ -18,8 +18,8 @@ extension UIViewController {
         onConfirm: @escaping () -> Void
     ) {
         let trimmedTitle = title.count > 20
-            ? String(title.prefix(20)) + "...는"
-            : title + "는"
+            ? String(title.prefix(20)) + "..."
+            : title
 
         let alert = UIAlertController(
             title: trimmedTitle,
@@ -27,7 +27,9 @@ extension UIViewController {
             preferredStyle: .alert
         )
 
-        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel) { _ in
+            onCancel()
+        })
         alert.addAction(UIAlertAction(title: "삭제", style: .destructive) { _ in
             onConfirm()
         })


### PR DESCRIPTION
## 📌 관련 이슈
close #210 
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- 방문하지 않은 클립 뷰 ListConfiguration으로 리팩터링
- DeleteAlert 확장으로 재사용
- 폴더뷰, 방문하지 않은 클립 뷰 Alert 적용

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/d46a3a6c-6368-4b75-ae92-06c67d736adf" width="250px"> |