### PR TITLE
내비게이션 타이틀 길이 제한

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Common/View/CommonNavigationView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/View/CommonNavigationView.swift
@@ -5,6 +5,7 @@ final class CommonNavigationView: UIView {
         let label = UILabel()
         label.font = .pretendard(size: 22, weight: .bold)
         label.textColor = .black100
+        label.textAlignment = .center
         return label
     }()
 
@@ -72,16 +73,17 @@ private extension CommonNavigationView {
     func setConstraints() {
         titleLabel.snp.makeConstraints { make in
             make.verticalEdges.equalToSuperview().inset(12)
-            make.centerX.equalToSuperview()
         }
 
         leftStackView.snp.makeConstraints { make in
             make.leading.equalToSuperview().offset(24)
+            make.trailing.equalTo(titleLabel.snp.leading).offset(-24)
             make.centerY.equalToSuperview()
         }
 
         rightStackView.snp.makeConstraints { make in
             make.trailing.equalToSuperview().inset(24)
+            make.leading.equalTo(titleLabel.snp.trailing).offset(24)
             make.centerY.equalToSuperview()
         }
     }

--- a/Clipster/Clipster/Presentation/Scene/Folder/Subview/View/FolderView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/Subview/View/FolderView.swift
@@ -125,6 +125,10 @@ private extension FolderView {
             make.directionalHorizontalEdges.equalToSuperview()
         }
 
+        backButton.snp.makeConstraints { make in
+            make.size.equalTo(48)
+        }
+
         addButton.snp.makeConstraints { make in
             make.size.equalTo(48)
         }


### PR DESCRIPTION
## 📌 관련 이슈

close #215 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

내비게이션 타이틀 길이보다 텍스트가 길어질 경우 말줄임표 처리

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/2862016e-6dc2-446e-87f2-0ab378191b1f" width="250px"> |
