### PR TITLE
폴더 편집 저장 버튼 활성화 조건 수정

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/EditFolder/ViewModel/EditFolderViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/ViewModel/EditFolderViewModel.swift
@@ -34,8 +34,10 @@ struct EditFolderState {
         switch mode {
         case .add:
             return true
-        case .edit:
-            return trimmed != initialFolderTitle
+        case .edit(_, let initialFolder):
+            let isTitleChanged = trimmed != initialFolderTitle
+            let isParentChanged = initialFolder.parentFolderID != parentFolder?.id
+            return isTitleChanged || isParentChanged
         }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈

close #230 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

폴더 편집 시 제목 / 저장폴더 중 하나만 수정되어도 저장 버튼 활성화 되도록 수정

## 📌 구현 내역 스크린샷

https://github.com/user-attachments/assets/9ce0afc8-4013-4271-a8e8-3862571fadc0
