### PR TITLE
헤더뷰 재사용으로 인한 중복 바인딩 해결

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/Cell/CollectionHeaderView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/Cell/CollectionHeaderView.swift
@@ -5,7 +5,7 @@ import UIKit
 
 final class CollectionHeaderView: UICollectionReusableView {
     let showAllTapped = PublishRelay<Void>()
-    private let disposeBag = DisposeBag()
+    private(set) var disposeBag = DisposeBag()
 
     private let titleLabel: UILabel = {
         let label = UILabel()
@@ -40,13 +40,19 @@ final class CollectionHeaderView: UICollectionReusableView {
     func setShowAllButtonVisible(_ isVisible: Bool) {
         showAllButton.isHidden = !isVisible
     }
+
+    func setBindings() {
+        disposeBag = DisposeBag()
+        showAllButton.rx.tap
+            .bind(to: showAllTapped)
+            .disposed(by: disposeBag)
+    }
 }
 
 private extension CollectionHeaderView {
     func configure() {
         setHierarchy()
         setConstraints()
-        setBindings()
     }
 
     func setHierarchy() {
@@ -67,11 +73,5 @@ private extension CollectionHeaderView {
             make.leading.greaterThanOrEqualTo(titleLabel).offset(12)
             make.trailing.equalToSuperview().inset(3.49)
         }
-    }
-
-    func setBindings() {
-        showAllButton.rx.tap
-            .bind(to: showAllTapped)
-            .disposed(by: disposeBag)
     }
 }

--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -115,18 +115,19 @@ final class HomeView: UIView {
         ) { [weak self] header, _, indexPath in
             guard
                 let self,
-                let sectionIdentifier = dataSource?.snapshot().sectionIdentifiers[indexPath.section]
+                let sectionIdentifier = dataSource?.sectionIdentifier(for: indexPath.section)
             else { return }
 
             switch sectionIdentifier {
             case .clip:
                 header.setTitle("방문하지 않은 클립")
                 header.setShowAllButtonVisible(true)
+                header.setBindings()
 
                 header.showAllTapped
                     .map { Action.showAllClips }
                     .bind(to: action)
-                    .disposed(by: disposeBag)
+                    .disposed(by: header.disposeBag)
             case .folder:
                 header.setTitle("폴더")
             }


### PR DESCRIPTION
## 📌 관련 이슈
close #231 
  
## 📌 PR 유형
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- 헤더뷰가 재사용되면서 중복 바인딩이 되어 이벤트가 중복 발생
- 재사용 시점마다 구독을 초기화하여 해결

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/5e6b8028-3005-46f1-b438-c3d41bc55189" width="250px"> |