### PR TITLE
FolderView에서 클립 열람시 visitIndicator 제거

### DIFF
--- a/Clipster/Clipster/App/DIContainer/DIContainer.swift
+++ b/Clipster/Clipster/App/DIContainer/DIContainer.swift
@@ -149,6 +149,7 @@ final class DIContainer {
             folder: folder,
             fetchFolderUseCase: makeFetchFolderUseCase(),
             deleteFolderUseCase: makeDeleteFolderUseCase(),
+            updateClipUseCase: makeUpdateClipUseCase(),
             deleteClipUseCase: makeDeleteClipUseCase()
         )
     }

--- a/Clipster/Clipster/Presentation/Scene/Folder/ViewModel/FolderViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/ViewModel/FolderViewModel.swift
@@ -36,17 +36,20 @@ final class FolderViewModel {
     private var folder: Folder
     private let fetchFolderUseCase: FetchFolderUseCase
     private let deleteFolderUseCase: DeleteFolderUseCase
+    private let updateClipUseCase: UpdateClipUseCase
     private let deleteClipUseCase: DeleteClipUseCase
 
     init(
         folder: Folder,
         fetchFolderUseCase: FetchFolderUseCase,
         deleteFolderUseCase: DeleteFolderUseCase,
+        updateClipUseCase: UpdateClipUseCase,
         deleteClipUseCase: DeleteClipUseCase,
     ) {
         self.folder = folder
         self.fetchFolderUseCase = fetchFolderUseCase
         self.deleteFolderUseCase = deleteFolderUseCase
+        self.updateClipUseCase = updateClipUseCase
         self.deleteClipUseCase = deleteClipUseCase
 
         state = BehaviorRelay(value: State(
@@ -75,6 +78,7 @@ private extension FolderViewModel {
                     case 0:
                         navigateToFolderView(at: indexPath.item)
                     case 1:
+                        updateLastVisitedDate(at: indexPath.item)
                         navigateToWebView(at: indexPath.item)
                     default:
                         break
@@ -109,6 +113,23 @@ private extension FolderViewModel {
                 clips: folder.clips.map(ClipDisplayMapper.map),
                 isEmptyViewHidden: !folder.folders.isEmpty || !folder.clips.isEmpty,
             ))
+        }
+    }
+
+    func updateLastVisitedDate(at index: Int) {
+        Task {
+            let clip = folder.clips[index]
+            let updatedClip = Clip(
+                id: clip.id,
+                folderID: clip.folderID,
+                urlMetadata: clip.urlMetadata,
+                memo: clip.memo,
+                lastVisitedAt: Date.now,
+                createdAt: clip.createdAt,
+                updatedAt: Date.now,
+                deletedAt: clip.deletedAt,
+            )
+            _ = await updateClipUseCase.execute(clip: updatedClip)
         }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈

close #240 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

FolderView에서 클립 열람시 visitIndicator 제거

## 📌 구현 내역 스크린샷

https://github.com/user-attachments/assets/dcc54c4e-55e0-4997-835e-d9a6cfee6908
