### PR TITLE
폴더 뷰에서 클립 추가 시 최근 수정된 폴더로 보이는 문제 해결

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -65,6 +65,7 @@ private extension EditClipViewController {
 
         viewModel.state
             .map { $0.type == .shareExtension }
+            .filter { $0 }
             .take(1)
             .subscribe { [weak self] _ in
                 self?.viewModel.action.accept(.fetchTopLevelFolder)

--- a/Clipster/Clipster/Presentation/Scene/Folder/ViewController/FolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/ViewController/FolderViewController.swift
@@ -58,13 +58,12 @@ private extension FolderViewController {
             .drive { [weak self] navigation in
                 guard let self else { return }
                 switch navigation {
-                case .editClipView(let clip):
-                    let vm: EditClipViewModel
-                    if let clip = clip {
-                        vm = diContainer.makeEditClipViewModel(clip: clip)
-                    } else {
-                        vm = diContainer.makeEditClipViewModel()
-                    }
+                case .editClipViewForAdd(let folder):
+                    let vm = diContainer.makeEditClipViewModel(folder: folder)
+                    let vc = EditClipViewController(viewModel: vm, diContainer: diContainer)
+                    navigationController?.pushViewController(vc, animated: true)
+                case .editClipViewForEdit(let clip):
+                    let vm = diContainer.makeEditClipViewModel(clip: clip)
                     let vc = EditClipViewController(viewModel: vm, diContainer: diContainer)
                     navigationController?.pushViewController(vc, animated: true)
                 case .editFolderView(let parentFolder, let folder):

--- a/Clipster/Clipster/Presentation/Scene/Folder/ViewModel/FolderViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/ViewModel/FolderViewModel.swift
@@ -21,7 +21,8 @@ final class FolderViewModel {
     }
 
     enum Navigation {
-        case editClipView(Clip?)
+        case editClipViewForAdd(Folder)
+        case editClipViewForEdit(Clip)
         case editFolderView(Folder, Folder?)
         case folderView(Folder)
         case clipDetailView(Clip)
@@ -144,7 +145,7 @@ private extension FolderViewModel {
     }
 
     func navigateToAddClipView() {
-        navigation.accept(.editClipView(nil))
+        navigation.accept(.editClipViewForAdd(folder))
     }
 
     func navigateToAddFolderView() {
@@ -168,7 +169,7 @@ private extension FolderViewModel {
             navigation.accept(.editFolderView(folder, selectedFolder))
         case 1:
             let selectedClip = folder.clips[indexPath.item]
-            navigation.accept(.editClipView(selectedClip))
+            navigation.accept(.editClipViewForEdit(selectedClip))
         default:
             break
         }


### PR DESCRIPTION
## 📌 관련 이슈

close #236 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- FolderView -> 클립 추가 시 폴더 파라미터 전달
- EditClipView init Type 예외처리 수정

