### PR TITLE
클립 그리드 셸 터치이벤트 비활성화 및 배지 색상 변경

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/Cell/ClipGirdCell.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/Cell/ClipGirdCell.swift
@@ -69,9 +69,9 @@ private extension ClipGridCell {
     }
 
     func setAttributes() {
-        backgroundColor = .white900
-        layer.cornerRadius = 12
-        clipsToBounds = true
+        contentView.backgroundColor = .white900
+        contentView.layer.cornerRadius = 12
+        contentView.clipsToBounds = true
     }
 
     func setHierarchy() {

--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/Cell/ClipGirdCell.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/Cell/ClipGirdCell.swift
@@ -29,6 +29,7 @@ final class ClipGridCell: UICollectionViewCell {
         textView.backgroundColor = .clear
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
+        textView.isUserInteractionEnabled = false
         return textView
     }()
 

--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/Cell/ClipGirdCell.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/Cell/ClipGirdCell.swift
@@ -13,7 +13,7 @@ final class ClipGridCell: UICollectionViewCell {
 
     private let visitIndicatorView: UIView = {
         let view = UIView()
-        view.backgroundColor = .systemBlue
+        view.backgroundColor = .blue400
         view.layer.cornerRadius = 6
         view.isHidden = true
         return view


### PR DESCRIPTION
## 📌 관련 이슈
close #243 
close #233 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- 클립 그리드 셸 TextView 터치이벤트 비활성화
- 배지 색상 변경
- contentView로 변경

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/ec0390b3-900c-41af-968f-8908675ae337" width="250px"> |

## 📌 참고 사항
- 타이틀 탭 할 경우에도 잘 동작되는거 확인했습니다.
