### PR TITLE
폴더 화면 단일 섹션일 때 여백 조정

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Folder/Subview/View/FolderView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/Subview/View/FolderView.swift
@@ -34,7 +34,7 @@ final class FolderView: UIView {
         tableView.backgroundColor = .white800
         tableView.rowHeight = 80
         tableView.separatorStyle = .none
-        tableView.sectionHeaderTopPadding = 23.5
+        tableView.sectionHeaderTopPadding = 0
         tableView.register(
             FolderCell.self,
             forCellReuseIdentifier: FolderCell.identifier,
@@ -134,7 +134,7 @@ private extension FolderView {
         }
 
         tableView.snp.makeConstraints { make in
-            make.top.equalTo(navigationView.snp.bottom)
+            make.top.equalTo(navigationView.snp.bottom).offset(24)
             make.directionalHorizontalEdges.equalTo(safeAreaLayoutGuide).inset(24)
             make.bottom.equalTo(safeAreaLayoutGuide)
         }
@@ -207,7 +207,36 @@ extension FolderView: UITableViewDelegate {
         _ tableView: UITableView,
         heightForHeaderInSection section: Int,
     ) -> CGFloat {
-        36
+        guard let section = Section(rawValue: section),
+              let items = dataSource?.snapshot().itemIdentifiers(inSection: section),
+              !items.isEmpty else { return .leastNonzeroMagnitude }
+
+        return 36
+    }
+
+    func tableView(
+        _ tableView: UITableView,
+        heightForFooterInSection section: Int
+    ) -> CGFloat {
+        guard section == 0,
+              let items = dataSource?.snapshot().itemIdentifiers(inSection: .folder),
+              !items.isEmpty else {
+            return 0
+        }
+
+        return 24
+    }
+
+    func tableView(
+        _ tableView: UITableView,
+        viewForFooterInSection section: Int,
+    ) -> UIView? {
+        guard section == 0 else { return nil }
+
+        let spacer = UIView()
+        spacer.backgroundColor = .clear
+
+        return spacer
     }
 
     func tableView(


### PR DESCRIPTION
## 📌 관련 이슈

close #232
close #238
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

폴더 화면에서 단일 섹션일 때, 테이블 뷰의 여백이 어색한 점을 수정했습니다.

## 📌 구현 내역 스크린샷

https://github.com/user-attachments/assets/ff189175-4a31-4a55-9e57-6229e35e1175
