### PR TITLE
폴더 편집 시 폴더 선택화면에서 자기 자신 제거

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -261,7 +261,7 @@ private extension EditClipViewController {
             .drive { [weak self] currentFolder in
                 guard let self else { return }
 
-                let vm = self.diContainer.makeFolderSelectorViewModel(mode: .folder(parentFolder: currentFolder))
+                let vm = self.diContainer.makeFolderSelectorViewModel(mode: .editClip(parentFolder: currentFolder))
                 let vc = FolderSelectorViewController(viewModel: vm, diContainer: self.diContainer)
                 vc.onSelectionComplete = {
                     self.viewModel.action.accept(.editFolder($0))

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
@@ -66,14 +66,14 @@ private extension EditFolderViewController {
             .disposed(by: disposeBag)
 
         state
-            .map { ($0.shouldNavigateToFolderSelector, $0.parentFolder) }
+            .map { ($0.shouldNavigateToFolderSelector, $0.folder, $0.parentFolder) }
             .distinctUntilChanged { $0.0 == $1.0 }
             .filter { $0.0 }
             .observe(on: MainScheduler.instance)
-            .subscribe { [weak self] _, parentFolder in
+            .subscribe { [weak self] _, folder, parentFolder in
                 guard let self else { return }
 
-                let vm = self.diContainer.makeFolderSelectorViewModel(mode: .folder(parentFolder: parentFolder))
+                let vm = self.diContainer.makeFolderSelectorViewModel(mode: .editFolder(folder: folder, parentFolder: parentFolder))
                 let vc = FolderSelectorViewController(viewModel: vm, diContainer: self.diContainer)
                 vc.onSelectionComplete = { selected in
                     self.viewModel.action.accept(.folderSelectorDismissed(selected: selected))

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/ViewModel/EditFolderViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/ViewModel/EditFolderViewModel.swift
@@ -25,6 +25,15 @@ struct EditFolderState {
     var parentFolder: Folder?
     var parentFolderDisplay: FolderDisplay?
 
+    var folder: Folder? {
+        switch mode {
+        case .add:
+            return nil
+        case .edit(_, let folder):
+            return folder
+        }
+    }
+
     var isSavable: Bool {
         let trimmed = folderTitle.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty {


### PR DESCRIPTION
## 📌 관련 이슈

close #250 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

폴더 선택 시 자기 자신을 선택하지 못하도록 테이블 뷰에서 보이지 않게함

## 📌 구현 내역 스크린샷

https://github.com/user-attachments/assets/636e0077-610b-4b02-805a-379ffb5993e1
