### PR TITLE
클립 상세 화면 저장폴더 타이틀에 말줄임표 적용

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/ClipDetail/Subview/View/ClipDetailView.swift
+++ b/Clipster/Clipster/Presentation/Scene/ClipDetail/Subview/View/ClipDetailView.swift
@@ -141,7 +141,7 @@ private extension ClipDetailView {
 
         folderRowView.snp.makeConstraints { make in
             make.verticalEdges.equalToSuperview().inset(12)
-            make.leading.equalToSuperview().offset(20)
+            make.directionalHorizontalEdges.equalToSuperview().inset(20)
         }
 
         activityIndicator.snp.makeConstraints { make in


### PR DESCRIPTION
## 📌 관련 이슈

close #260 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

클립 상세 화면 저장폴더 타이틀에 말줄임표 적용

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/b354fe54-abc6-4774-94dd-53d32473233b" width="250px"> |
