### PR TITLE
InteractivePopGesture 활성화

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/ClipDetail/ViewController/ClipDetailViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/ClipDetail/ViewController/ClipDetailViewController.swift
@@ -35,7 +35,12 @@ final class ClipDetailViewController: UIViewController {
 
 private extension ClipDetailViewController {
     func configure() {
+        setDelegates()
         setBindings()
+    }
+
+    func setDelegates() {
+        navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
 
     func setBindings() {
@@ -147,5 +152,11 @@ private extension ClipDetailViewController {
             .map { ClipDetailAction.deleteButtonTapped }
             .bind(to: viewModel.action)
             .disposed(by: disposeBag)
+    }
+}
+
+extension ClipDetailViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        true
     }
 }

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -33,11 +33,16 @@ final class EditClipViewController: UIViewController {
 private extension EditClipViewController {
     func configure() {
         setAttributes()
+        setDelegates()
         setBindings()
     }
 
     func setAttributes() {
         view.backgroundColor = .white800
+    }
+
+    func setDelegates() {
+        navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
 
     func setBindings() {
@@ -309,5 +314,11 @@ private extension EditClipViewController {
             .asDriver(onErrorDriveWith: .empty())
             .drive(editClipView.emptyView.rx.isHidden)
             .disposed(by: disposeBag)
+    }
+}
+
+extension EditClipViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        true
     }
 }

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
@@ -35,7 +35,12 @@ final class EditFolderViewController: UIViewController {
 
 private extension EditFolderViewController {
     func configure() {
+        setDelegates()
         setBindings()
+    }
+
+    func setDelegates() {
+        navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
 
     func setBindings() {
@@ -153,5 +158,11 @@ private extension EditFolderViewController {
             .map { _ in .folderViewTapped }
             .bind(to: viewModel.action)
             .disposed(by: disposeBag)
+    }
+}
+
+extension EditFolderViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        true
     }
 }

--- a/Clipster/Clipster/Presentation/Scene/Folder/ViewController/FolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/Folder/ViewController/FolderViewController.swift
@@ -1,7 +1,6 @@
 import RxCocoa
 import RxSwift
 import SafariServices
-import SnapKit
 import UIKit
 
 final class FolderViewController: UIViewController {
@@ -39,7 +38,12 @@ final class FolderViewController: UIViewController {
 
 private extension FolderViewController {
     func configure() {
+        setDelegates()
         setBindings()
+    }
+
+    func setDelegates() {
+        navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
 
     func setBindings() {
@@ -148,5 +152,11 @@ private extension FolderViewController {
                 }
             }
             .disposed(by: disposeBag)
+    }
+}
+
+extension FolderViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        true
     }
 }

--- a/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewController/UnvisitedClipListViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/UnvisitedClipList/ViewController/UnvisitedClipListViewController.swift
@@ -1,6 +1,6 @@
 import RxCocoa
-import SafariServices
 import RxSwift
+import SafariServices
 import UIKit
 
 final class UnvisitedClipListViewController: UIViewController {
@@ -38,11 +38,16 @@ final class UnvisitedClipListViewController: UIViewController {
 private extension UnvisitedClipListViewController {
     func configure() {
         setAttributes()
+        setDelegates()
         setBindings()
     }
 
     func setAttributes() {
         title = "방문하지 않은 클립"
+    }
+
+    func setDelegates() {
+        navigationController?.interactivePopGestureRecognizer?.delegate = self
     }
 
     func setBindings() {
@@ -101,5 +106,11 @@ private extension UnvisitedClipListViewController {
                 }
             }
             .disposed(by: disposeBag)
+    }
+}
+
+extension UnvisitedClipListViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        true
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈

close #225
  
## 📌 PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

화면 왼쪽에서 안쪽으로 스와이프할 때, VC가 pop되는 기능을 활성화 했습니다(InteractivePopGesture 활성화)

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/1b6e9770-8a4c-4471-9dc9-11e8f95cbf6a" width="250px"> |

## 📌 참고 사항

```swift
extension EditFolderViewController: UIGestureRecognizerDelegate {
    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
        true
    }
}
```

이렇게 다 안쓰고, 그냥 Delegate를 채택하기만 해도 원하는 대로 동작은 하는 것 같습니다.

```swift
extension EditFolderViewController: UIGestureRecognizerDelegate {}
```

근데 나중에 왜 추가했는지 못알아볼 것 같아서 그냥 명시적으로 메서드 작성했습니다.