### PR TITLE
클립 추가/편집 화면에서 폴더 선택 시 홈이 선택되는 버그 수정

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/ViewController/EditFolderViewController.swift
@@ -76,7 +76,10 @@ private extension EditFolderViewController {
                 let vm = self.diContainer.makeFolderSelectorViewModel(mode: .editFolder(folder: folder, parentFolder: parentFolder))
                 let vc = FolderSelectorViewController(viewModel: vm, diContainer: self.diContainer)
                 vc.onSelectionComplete = { selected in
-                    self.viewModel.action.accept(.folderSelectorDismissed(selected: selected))
+                    self.viewModel.action.accept(.selectFolder(selected: selected))
+                }
+                vc.onDismissed = {
+                    self.viewModel.action.accept(.folderSelectorDismissed)
                 }
                 vc.modalPresentationStyle = .pageSheet
 

--- a/Clipster/Clipster/Presentation/Scene/EditFolder/ViewModel/EditFolderViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditFolder/ViewModel/EditFolderViewModel.swift
@@ -13,7 +13,8 @@ enum EditFolderAction {
     case folderViewTapped
     case saveSucceeded(Folder)
     case saveFailed(Error)
-    case folderSelectorDismissed(selected: Folder?)
+    case selectFolder(selected: Folder?)
+    case folderSelectorDismissed
 }
 
 struct EditFolderState {
@@ -128,15 +129,17 @@ final class EditFolderViewModel {
                     print("\(Self.self): save failed with error: \(error.localizedDescription)")
                     newState.isProcessing = false
                     newState.alertMessage = error.localizedDescription
-                case .folderSelectorDismissed(let selected):
-                    print("\(Self.self): folder selector dismissed with selection → \(selected?.title ?? "home")")
-                    newState.shouldNavigateToFolderSelector = false
+                case .selectFolder(let selected):
+                    print("\(Self.self): selected folder  \(selected?.title ?? "home")")
                     newState.parentFolder = selected
                     if let selected {
                         newState.parentFolderDisplay = FolderDisplayMapper.map(selected)
                     } else {
                         newState.parentFolderDisplay = nil
                     }
+                case .folderSelectorDismissed:
+                    print("\(Self.self): folder selector dismissed")
+                    newState.shouldNavigateToFolderSelector = false
                 }
 
                 return newState

--- a/Clipster/Clipster/Presentation/Scene/FolderSelector/ViewController/FolderSelectorViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/FolderSelector/ViewController/FolderSelectorViewController.swift
@@ -9,6 +9,7 @@ final class FolderSelectorViewController: UIViewController {
     private let folderSelectorView = FolderSelectorView()
 
     var onSelectionComplete: ((Folder?) -> Void)?
+    var onDismissed: (() -> Void)?
 
     init(viewModel: FolderSelectorViewModel, diContainer: DIContainer) {
         self.viewModel = viewModel
@@ -32,7 +33,7 @@ final class FolderSelectorViewController: UIViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        viewModel.action.accept(.viewWillDisappear)
+        onDismissed?()
     }
 }
 

--- a/Clipster/Clipster/Presentation/Scene/FolderSelector/ViewModel/FolderSelectorViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/FolderSelector/ViewModel/FolderSelectorViewModel.swift
@@ -24,7 +24,6 @@ enum FolderSelectorMode {
 
 enum FolderSelectorAction {
     case viewDidLoad
-    case viewWillDisappear
     case dataLoadedSucceeded(folders: [Folder])
     case dataLoadFailed(Error)
     case openSubfolder(folder: Folder)
@@ -148,9 +147,6 @@ final class FolderSelectorViewModel {
                 case .viewDidLoad:
                     print("\(Self.self): viewDidLoad")
                     state.isLoading = true
-                case .viewWillDisappear:
-                    print("\(Self.self): viewWillDisappear")
-                    state.shouldDismiss = true
                 case .dataLoadedSucceeded(let folders):
                     print("\(Self.self): data load succeeded with \(folders.count) folders")
                     state.isLoading = false


### PR DESCRIPTION
## 📌 관련 이슈

close #229 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

클립 추가/편집 화면 -> 폴더 선택 화면에서 홈 선택 비활성화

## 📌 구현 내역 스크린샷

https://github.com/user-attachments/assets/5fbf6030-d3c1-4c3e-a0a7-cd6021d22be5
