### PR TITLE
홈 폴더 섹션만 있을경우 위쪽 여백 다름 해결 및 기타 수정

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/Cell/ClipGirdCell.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/Cell/ClipGirdCell.swift
@@ -70,8 +70,8 @@ private extension ClipGridCell {
 
     func setAttributes() {
         contentView.backgroundColor = .white900
-        contentView.layer.cornerRadius = 12
-        contentView.clipsToBounds = true
+        layer.cornerRadius = 12
+        clipsToBounds = true
     }
 
     func setHierarchy() {

--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -84,7 +84,11 @@ final class HomeView: UIView {
         return collectionView
     }()
 
-    private let emptyView = EmptyView()
+    private let emptyView: EmptyView = {
+        let view = EmptyView()
+        view.isHidden = true
+        return view
+    }()
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -269,7 +269,7 @@ private extension HomeView {
         func makeHeaderItemLayout(for section: Section) -> NSCollectionLayoutBoundarySupplementaryItem {
             let headerSize = NSCollectionLayoutSize(
                 widthDimension: .fractionalWidth(1.0),
-                heightDimension: .absolute(28)
+                heightDimension: .absolute(48)
             )
 
             let header = NSCollectionLayoutBoundarySupplementaryItem(

--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -201,7 +201,7 @@ private extension HomeView {
     func createCollectionViewLayout() -> UICollectionViewLayout {
         let layout = UICollectionViewCompositionalLayout { [weak self] index, env -> NSCollectionLayoutSection? in
             guard let self,
-                  let sectionKind = self.dataSource?.snapshot().sectionIdentifiers[index]
+                  let sectionKind = dataSource?.sectionIdentifier(for: index)
             else { return nil }
 
             switch sectionKind {
@@ -244,6 +244,7 @@ private extension HomeView {
         config.showsSeparators = false
         config.backgroundColor = .white800
         config.headerMode = .supplementary
+        config.headerTopPadding = 0
         config.trailingSwipeActionsConfigurationProvider = { [weak self] indexPath in
             let delete = UIContextualAction(
                 style: .destructive,

--- a/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Home/Subview/View/HomeView.swift
@@ -52,9 +52,6 @@ final class HomeView: UIView {
         let text = "담담"
         let font = UIFont(name: "locus_sangsang", size: 28) ?? UIFont.boldSystemFont(ofSize: 28)
         let attributedText = NSMutableAttributedString(string: text)
-        attributedText.addAttribute(.foregroundColor, value: UIColor.systemBlue, range: NSRange(location: 0, length: 1))
-        attributedText.addAttribute(.foregroundColor, value: UIColor.systemYellow, range: NSRange(location: 1, length: 1))
-
         attributedText.addAttributes([
             .foregroundColor: UIColor.blue600,
             .font: font
@@ -64,7 +61,6 @@ final class HomeView: UIView {
             .foregroundColor: UIColor.blue700,
             .font: font
         ], range: NSRange(location: 1, length: 1))
-
         label.attributedText = attributedText
 
         return label


### PR DESCRIPTION
## 📌 관련 이슈
- close #266 
- close #271 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- 폴더 섹션 TopPadding 기본값으로 인하여 여백 증가 -> 0으로 설정
- 헤더 높이 48로 변경
- EmptyView 초기 Hidden 처리
- Cell CornerRadius self로 변경

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/786bb703-435b-4da6-a576-62c61bf820cf" width="250px"> |