### PR TITLE
EditClipView 폴더 재선택 안 되는 이슈 해결

### DIFF
--- a/Clipster/Clipster/Domain/UseCase/URLValidation/DefaultCheckVaildityUseCase.swift
+++ b/Clipster/Clipster/Domain/UseCase/URLValidation/DefaultCheckVaildityUseCase.swift
@@ -10,7 +10,7 @@ final class DefaultCheckValidityUseCase: CheckURLValidityUseCase {
     func execute(urlString: String) async -> Result<Bool, Error> {
         let correctedURLString = urlString.lowercased().hasPrefix("https://") ?
         urlString : "https://\(urlString)"
-        
+
         guard let url = URL(string: correctedURLString) else {
             return .failure(URLError(.badURL))
         }

--- a/Clipster/Clipster/Presentation/Scene/EditClip/Subview/View/EditClipView.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/Subview/View/EditClipView.swift
@@ -14,7 +14,6 @@ final class EditClipView: UIView {
 
     private let scrollView: UIScrollView = {
         let scrollView = UIScrollView()
-        scrollView.alwaysBounceVertical = true
         scrollView.showsHorizontalScrollIndicator = false
         return scrollView
     }()
@@ -116,8 +115,8 @@ private extension EditClipView {
             memoView,
             folderLabel,
             addFolderButton,
-            emptyView,
-            folderView
+            folderView,
+            emptyView
         ].forEach {
             scrollContainerView.addSubview($0)
         }
@@ -172,6 +171,7 @@ private extension EditClipView {
             make.top.equalToSuperview().offset(24)
             make.directionalHorizontalEdges.equalToSuperview().inset(24)
             make.width.equalToSuperview().inset(24)
+            make.height.equalTo(0).priority(.low)
         }
 
         urlInputTextField.snp.makeConstraints { make in
@@ -196,7 +196,9 @@ private extension EditClipView {
         folderView.snp.makeConstraints { make in
             make.top.equalTo(folderLabel.snp.bottom).offset(12)
             make.directionalHorizontalEdges.equalToSuperview().inset(28)
+            make.bottom.lessThanOrEqualToSuperview().inset(20)
             make.height.equalTo(72)
+            make.width.equalToSuperview().inset(28)
         }
 
         folderRowView.snp.makeConstraints { make in
@@ -212,7 +214,7 @@ private extension EditClipView {
         }
 
         emptyView.snp.makeConstraints { make in
-            make.top.equalTo(folderView.snp.top)
+            make.top.equalTo(folderLabel.snp.bottom).offset(12)
             make.height.greaterThanOrEqualTo(155)
             make.directionalHorizontalEdges.equalToSuperview()
             make.bottom.equalToSuperview().inset(20)

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -272,7 +272,6 @@ private extension EditClipViewController {
                 guard state.isFolderViewTapped else { return nil }
                 return state.currentFolder
             }
-            .distinctUntilChanged { $0.id == $1.id }
             .asDriver(onErrorDriveWith: .empty())
             .drive { [weak self] currentFolder in
                 guard let self else { return }
@@ -281,6 +280,7 @@ private extension EditClipViewController {
                 let vc = FolderSelectorViewController(viewModel: vm, diContainer: self.diContainer)
                 vc.onSelectionComplete = {
                     self.viewModel.action.accept(.editFolder($0))
+                    self.viewModel.action.accept(.folderSelectorViewDisappeared)
                 }
                 vc.modalPresentationStyle = .pageSheet
 

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -250,11 +250,7 @@ private extension EditClipViewController {
             .asDriver(onErrorDriveWith: .empty())
             .drive { [weak self] in
                 self?.editClipView.folderRowView.setDisplay(
-                    FolderDisplay(
-                        id: $0.id,
-                        title: $0.title,
-                        itemCount: "\($0.clips.count + $0.folders.count)개 항목"
-                    )
+                    FolderDisplayMapper.map($0)
                 )
             }
             .disposed(by: disposeBag)

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -253,7 +253,7 @@ private extension EditClipViewController {
                     FolderDisplay(
                         id: $0.id,
                         title: $0.title,
-                        itemCount: "\($0.clips.count + $0.folders.count)개 항목"
+                        itemCount: "\($0.clips.count + $0.folders.count) 개 항목"
                     )
                 )
             }

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -253,7 +253,7 @@ private extension EditClipViewController {
                     FolderDisplay(
                         id: $0.id,
                         title: $0.title,
-                        itemCount: "\($0.clips.count + $0.folders.count) 개 항목"
+                        itemCount: "\($0.clips.count + $0.folders.count)개 항목"
                     )
                 )
             }

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -176,9 +176,9 @@ private extension EditClipViewController {
 
         viewModel.state
             .map(\.urlValidationImageName)
-            .map { UIImage(named: $0) }
+            .compactMap { UIImage(named: $0) }
             .distinctUntilChanged()
-            .asDriver(onErrorDriveWith: .empty())
+            .asDriver(onErrorJustReturn: .none)
             .drive(editClipView.urlValidationStacKView.statusImageView.rx.image)
             .disposed(by: disposeBag)
 

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewController/EditClipViewController.swift
@@ -175,7 +175,7 @@ private extension EditClipViewController {
             .disposed(by: disposeBag)
 
         viewModel.state
-            .map(\.urlValidationImageName)
+            .compactMap(\.urlValidationImageName)
             .compactMap { UIImage(named: $0) }
             .distinctUntilChanged()
             .asDriver(onErrorJustReturn: .none)

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
@@ -20,6 +20,7 @@ final class EditClipViewModel: ViewModel {
         case fetchTopLevelFolder
         case editBeginURLTextField
         case editEndURLTextField
+        case folderSelectorViewDisappeared
     }
 
     enum Mutation {
@@ -228,6 +229,9 @@ final class EditClipViewModel: ViewModel {
         case .editEndURLTextField:
             print("\(Self.self) \(action)")
             return .just(.updateURLTextFieldBorderColor(.black900))
+        case .folderSelectorViewDisappeared:
+            print("\(Self.self) \(action)")
+            return .just(.updateFolderViewTapped(false))
         }
     }
 

--- a/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
+++ b/Clipster/Clipster/Presentation/Scene/EditClip/ViewModel/EditClipViewModel.swift
@@ -43,7 +43,7 @@ final class EditClipViewModel: ViewModel {
         var memoText: String = ""
         var memoLimit: String = "0 / 100"
         var isURLValid = false
-        var urlValidationImageName: String = ""
+        var urlValidationImageName: String?
         var urlValidationLabelText: String = ""
         var urlMetadata: URLMetadataDisplay?
         var isFolderViewTapped: Bool = false
@@ -264,7 +264,7 @@ final class EditClipViewModel: ViewModel {
         case .updateIsLoading(let value):
             newState.isLoading = value
             newState.urlValidationLabelText = "URL 분석 중..."
-            newState.urlValidationImageName = ""
+            newState.urlValidationImageName = nil
         }
         return newState
     }


### PR DESCRIPTION
## 📌 관련 이슈

close #273 
  
## 📌 PR 유형

- [] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- xcode CUICatalog 관련 경고 메시지 수정
- 폴더 항목 개수 표시 형식 수정
- 폴더 재선택 안 되는 문제 수정
