### PR TITLE
URL Scheme 구분하여 Share Extension 이슈 해결

### DIFF
--- a/Clipster/Clipster/App/Derived/Info.plist
+++ b/Clipster/Clipster/App/Derived/Info.plist
@@ -11,7 +11,19 @@
 			<string>com.saltshaker.clipster</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>clipster</string>
+				<string>damdam</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLIconFile</key>
+			<string></string>
+			<key>CFBundleURLName</key>
+			<string>com.saltshaker.clipster.debug</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>damdamdebug</string>
 			</array>
 		</dict>
 	</array>

--- a/Clipster/Clipster/App/Source/SceneDelegate.swift
+++ b/Clipster/Clipster/App/Source/SceneDelegate.swift
@@ -1,6 +1,14 @@
 import UIKit
 
 final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    private let appGroupID: String = {
+        #if DEBUG
+        return "group.com.saltshaker.clipster.debug"
+        #else
+        return "group.com.saltshaker.clipster"
+        #endif
+    }()
+
     var window: UIWindow?
 
     func scene(
@@ -20,7 +28,7 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     func sceneDidBecomeActive(_ scene: UIScene) {
-        if let sharedDefaults = UserDefaults(suiteName: "group.com.saltshaker.clipster"),
+        if let sharedDefaults = UserDefaults(suiteName: appGroupID),
            let urlString = sharedDefaults.string(forKey: "sharedURL") {
             sharedDefaults.removeObject(forKey: "sharedURL")
 

--- a/Clipster/ShareExtension/ShareViewController.swift
+++ b/Clipster/ShareExtension/ShareViewController.swift
@@ -11,6 +11,14 @@ final class ShareViewController: SLComposeViewController {
         #endif
     }()
 
+    private let urlScheme: String = {
+        #if DEBUG
+        return "damdamdebug://"
+        #else
+        return "damdam://"
+        #endif
+    }()
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         extractURL()
@@ -53,7 +61,7 @@ final class ShareViewController: SLComposeViewController {
     }
 
     private func openMainApp() {
-        if let url = URL(string: "clipster://") {
+        if let url = URL(string: urlScheme) {
             if openURLScheme(url) {
                 print("\(Self.self) ✅ URL Scheme open 성공")
             } else {


### PR DESCRIPTION
## 📌 관련 이슈

close #287 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

Debug와 Release Bundle Identifier 구분에 따라 같이 수정됐어야 하는 부분들을 수정했습니다.
기존 단일 URL Scheme이였던 `clipster://`를 `damdamdebug://`와 `damdam://`으로 변경했습니다.

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/3c805fa3-4c81-4ca5-a142-9c863aedabfa" width="250px"> |
