### PR TITLE
메모 텍스트뷰 높이 수정

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Common/View/MemoView.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/View/MemoView.swift
@@ -67,11 +67,11 @@ private extension MemoView {
             make.top.equalTo(titleLabel.snp.bottom).offset(8)
             make.directionalHorizontalEdges.equalToSuperview().inset(24)
             make.bottom.equalToSuperview().inset(16)
+            make.height.equalTo(96)
         }
 
         memoTextView.snp.makeConstraints { make in
             make.top.directionalHorizontalEdges.equalToSuperview().inset(12)
-            make.height.equalTo(96)
         }
 
         memoLimitLabel.snp.makeConstraints { make in


### PR DESCRIPTION
## 📌 관련 이슈

close #298 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유

피그마대로 높이 수정

## 📌 구현 내역 스크린샷

| 실행 기기 | 스크린샷(또는 GIF) |
| :-------------: | :----------: |
| iPhone 16 Pro | <img src="https://github.com/user-attachments/assets/0cef4aaa-bf6b-4f32-8963-12a5914f9582" width="250px"> |
