### PR TITLE
FolderListCell 오토레이아웃 경고 해결

### DIFF
--- a/Clipster/Clipster/Presentation/Scene/Common/Cell/FolderListCell.swift
+++ b/Clipster/Clipster/Presentation/Scene/Common/Cell/FolderListCell.swift
@@ -92,8 +92,9 @@ private extension FolderListCell {
 
     func setConstraints() {
         folderImageContainerView.snp.makeConstraints { make in
+            make.top.equalToSuperview().inset(12)
             make.leading.equalToSuperview().inset(44)
-            make.verticalEdges.equalToSuperview().inset(12)
+            make.bottom.equalToSuperview().inset(12).priority(.high)
             make.size.equalTo(48)
         }
 
@@ -103,14 +104,14 @@ private extension FolderListCell {
 
         stackView.snp.makeConstraints { make in
             make.leading.equalTo(folderImageContainerView.snp.trailing).offset(16)
-            make.verticalEdges.equalToSuperview().inset(12.5)
+            make.centerY.equalToSuperview()
         }
 
         chevronImageView.snp.makeConstraints { make in
             make.leading.equalTo(stackView.snp.trailing).offset(16)
             make.trailing.equalToSuperview().inset(24)
-            make.verticalEdges.equalToSuperview().inset(24)
             make.size.equalTo(24)
+            make.centerY.equalToSuperview()
         }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
close #295 
  
## 📌 PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩터링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩터링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📌 변경 사항 및 이유
- top(24) + size(48) + bottom(24) = 72 를 기대하지만 UIkit에서 내부적으로 계산한 높이는 72와 다를수 있음
- 이로인해 충돌이 발생한 것으로 추정
- 이를 해결하기 위해 우선순위를 낮춤으로써 UIkit에서 계산한 높이를 사용할 수 있도록 수정